### PR TITLE
fix(crosswalk): defensively dedupe ESPN games in mbb_schedule_crosswalk

### DIFF
--- a/R/mbb_crosswalk.R
+++ b/R/mbb_crosswalk.R
@@ -432,6 +432,9 @@ mbb_team_crosswalk <- function(season = most_recent_mbb_season(),
     espn_game_id      = as.character(.data$espn_game_id),
     .pair_key         = .pair_key(.data$home_espn_team_id, .data$away_espn_team_id)
   )
+  # Defensive: collapse any ESPN games duplicated across scoreboard groups to
+  # one row per game before the join (mirrors wehoop's WBB schedule assembler).
+  espn2 <- espn2[!duplicated(espn2$espn_game_id), , drop = FALSE]
 
   # Torvik side — only keep games where both teams resolved to ESPN ids
   bart2 <- data.frame(
@@ -448,6 +451,7 @@ mbb_team_crosswalk <- function(season = most_recent_mbb_season(),
   bart2$.pair_key <- .pair_key(bart2$.t1_id, bart2$.t2_id)
   bart2$.t1_id <- NULL
   bart2$.t2_id <- NULL
+  bart2 <- bart2[!duplicated(bart2$bart_muid), , drop = FALSE]
 
   key <- c("game_date", ".pair_key")
   out <- dplyr::full_join(espn2, bart2, by = key) |>

--- a/tests/testthat/test-mbb_crosswalk.R
+++ b/tests/testthat/test-mbb_crosswalk.R
@@ -284,6 +284,22 @@ test_that("schedule assembler: both-match row", {
   expect_equal(out$match_confidence, 1)
 })
 
+test_that("schedule assembler dedupes ESPN games repeated across scoreboard groups", {
+  # Regression: a per-date ESPN scoreboard pull can return the same game once
+  # per group; the assembler must collapse duplicates to a single joined row.
+  xwalk <- .make_sched_xwalk()
+  eg    <- .make_espn_games(rep("2025-01-10", 4), rep(1L, 4), rep(2L, 4), rep("E001", 4))
+  bg    <- .make_bart_games("2025-01-10", "Duke", "North Carolina", "B001", "Duke")
+
+  out <- .bb_assemble_schedule_crosswalk_mbb(
+    espn_games = eg, bart_games = bg, team_xwalk = xwalk, season = 2025L
+  )
+
+  expect_equal(nrow(out), 1L)
+  expect_equal(out$match_method, "both")
+  expect_equal(out$espn_game_id, "E001")
+})
+
 test_that("schedule assembler: espn_only when no Torvik match", {
   xwalk <- .make_sched_xwalk()
   eg    <- .make_espn_games("2025-01-12", 1L, 3L, "E002")


### PR DESCRIPTION
Defensive mirror of the wehoop WBB schedule fix (sportsdataverse/wehoop#61). De-duplicate the ESPN frame on `espn_game_id` (and Torvik on `bart_muid`) before the pair-key full-join, so `mbb_schedule_crosswalk()` can't inflate if `espn_mbb_scoreboard()` ever returns a game once per ESPN group. MBB is currently clean (no inflation), so this is a guard + parallel-logic change; adds a regression test.

## Test Plan
- [x] `test-mbb_crosswalk.R` passes (incl. new dedupe regression test)
