### PR TITLE
fix(espn): derive boxscore availability from the payload, not the header flag

### DIFF
--- a/R/espn_mbb_data.R
+++ b/R/espn_mbb_data.R
@@ -3246,7 +3246,12 @@ helper_espn_mbb_team_box <- function(resp) {
     lubridate::with_tz(tzone = "America/New_York")
 
   game_date <- as.Date(substr(game_date_time, 0, 10))
-  box_score_available <- game_json[["header"]][["competitions"]][["boxscoreAvailable"]]
+  # ESPN's header `boxscoreAvailable` flag is unreliable for archival games
+  # (pre-2014 WBB payloads carry full stats while the flag says FALSE -- the
+  # same latent gate silently dropped a decade of wehoop boxscores), so
+  # availability is derived from the payload itself; the statistics-length
+  # check below remains the real gate.
+  box_score_available <- length(game_json[["boxscore"]][["teams"]]) > 0
   if (box_score_available == TRUE) {
     teams_box_score_df <- game_json[["boxscore"]][["teams"]] %>%
       jsonlite::toJSON() %>%
@@ -3489,7 +3494,9 @@ helper_espn_mbb_player_box <- function(resp) {
       purrr::pluck(7) %>%
       as.numeric()
   )
-  if (boxScoreAvailable == TRUE &&
+  # Payload presence replaces ESPN's unreliable header `boxscoreAvailable`
+  # flag; the athlete and stat validity conjuncts below remain the real gate.
+  if (length(game_json[["boxscore"]][["players"]]) > 0 &&
     length(players_box_score_df[["statistics"]][[1]][["athletes"]][[1]]) > 1 &&
     length(players_box_score_df[["statistics"]][[1]][["athletes"]][[1]][["stats"]][[1]]) > 1 &&
     valid_athletes &&

--- a/R/espn_nba_data.R
+++ b/R/espn_nba_data.R
@@ -3298,9 +3298,12 @@ helper_espn_nba_team_box <- function(resp) {
     lubridate::with_tz(tzone = "America/New_York")
 
   game_date <- as.Date(substr(game_date_time, 0, 10))
-  box_score_available <- game_json[["header"]][["competitions"]][[
-    "boxscoreAvailable"
-  ]]
+  # ESPN's header `boxscoreAvailable` flag is unreliable for archival games
+  # (pre-2014 WBB payloads carry full stats while the flag says FALSE -- the
+  # same latent gate silently dropped a decade of wehoop boxscores), so
+  # availability is derived from the payload itself; the statistics-length
+  # check below remains the real gate.
+  box_score_available <- length(game_json[["boxscore"]][["teams"]]) > 0
   if (box_score_available == TRUE) {
     teams_box_score_df <- game_json[["boxscore"]][["teams"]] %>%
       jsonlite::toJSON() %>%
@@ -3639,7 +3642,9 @@ helper_espn_nba_player_box <- function(resp) {
       as.numeric()
   )
   if (
-    boxScoreAvailable == TRUE &&
+    # Payload presence replaces ESPN's unreliable header `boxscoreAvailable`
+    # flag; the athlete and stat validity conjuncts below remain the real gate.
+    length(game_json[["boxscore"]][["players"]]) > 0 &&
       length(players_box_score_df[["statistics"]][[1]][["athletes"]][[1]]) >
         1 &&
       !is.na(valid_stats)


### PR DESCRIPTION
Ports sportsdataverse/wehoop#64 to the MBB/NBA helpers: ESPN's header
boxscoreAvailable flag is unreliable for archival games (pre-2014 WBB
payloads carry full statistics under a FALSE flag -- that gate silently
dropped a decade of wehoop boxscores; sampled MBB 2004 games show the
inverse, flag TRUE with no stats, so the gate adds nothing here either).
All four helpers (team/player box, MBB/NBA) now gate on payload presence;
the existing statistics-length / athlete-validity checks remain the real
gate, so genuinely boxless games still return empty.

Verified: both files parse; the patched helpers extract 2 team rows + 10
player rows from a real flag-false archival payload (previously empty).
Python side (sdv-py) never had the gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of available NCAA and NBA box-score data.
  * Box scores are now processed correctly when ESPN’s availability indicator is inaccurate or missing.
  * Preserved existing outputs and functionality for team and player statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->