### PR TITLE
fix(docs): address player_core review findings + repair the pkgdown reference index

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -41,3 +41,9 @@ mbb_pbp_db
 ^\.DS_Store$
 ^Meta$
 ^doc$
+^\.omc$
+^\.remember$
+^\.ruff_cache$
+^\.pytest_cache$
+^\.understand-anything$
+^\.superpowers$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -47,3 +47,6 @@ mbb_pbp_db
 ^\.pytest_cache$
 ^\.understand-anything$
 ^\.superpowers$
+^debug\.log$
+^nul$
+^.*\.log$

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ md*
 /.vscode
 /.claude
 .positai
+debug.log
+nul
+*.log

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -701,7 +701,6 @@ importFrom(stringr,
   str_sub,
   str_trim
 )
-importFrom(tibble,as_tibble)
 importFrom(tidyr,
   everything,
   hoist,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -701,6 +701,7 @@ importFrom(stringr,
   str_sub,
   str_trim
 )
+importFrom(tibble,as_tibble)
 importFrom(tidyr,
   everything,
   hoist,

--- a/NEWS.md
+++ b/NEWS.md
@@ -197,7 +197,7 @@ no key required:
   players and average age from [Spotrac](https://www.spotrac.com).
 - **`hoopshype_salaries()`** — the **full league's** player salaries (one row
   per player-season, current + future contract years) from
-  [HoopsHype](https://hoopshype.com). HoopsHype is now a Next.js app whose
+  [HoopsHype](https://www.hoopshype.com/). HoopsHype is now a Next.js app whose
   single salaries page paginates client-side, but each team page embeds that
   team's complete roster in its `__NEXT_DATA__` payload — so this iterates the 30
   team pages and stitches them together (~600 players) via a team-by-team

--- a/R/espn_basketball_player_core.R
+++ b/R/espn_basketball_player_core.R
@@ -96,7 +96,6 @@ NULL
 #' published and neither depends on the other, so here it is duplicated:
 #' **a change to one must land in the other in the same session, verified.**
 #' @author Saiem Gilani
-#' @importFrom tibble as_tibble
 #' @importFrom janitor clean_names
 #' @family Basketball Analytics Utilities
 #' @export

--- a/R/espn_basketball_player_core.R
+++ b/R/espn_basketball_player_core.R
@@ -81,10 +81,16 @@ NULL
 #'
 #' @examples
 #' \donttest{
+#'   # Split across lines to keep the Rd under the line-width limit; the
+#'   # core-v2 $ref URLs are long enough to be truncated in the PDF manual.
+#'   team_ref <- paste0(
+#'     "http://sports.core.api.espn.com/v2/sports/basketball/",
+#'     "leagues/nba/seasons/2025/teams/22"
+#'   )
 #'   payload <- list(
 #'     guid = "abc", fullName = "Jane Doe", jersey = "23",
 #'     position = list(id = "5", abbreviation = "G"),
-#'     team = list(`$ref` = "http://sports.core.api.espn.com/v2/sports/basketball/leagues/nba/seasons/2025/teams/22")
+#'     team = list(`$ref` = team_ref)
 #'   )
 #'   espn_basketball_player_core(payload, athlete_id = 1966)
 #' }

--- a/R/espn_basketball_player_core.R
+++ b/R/espn_basketball_player_core.R
@@ -158,9 +158,7 @@ espn_basketball_player_core <- function(payload, athlete_id) {
     active = .pc_lgl(payload[["active"]])
   )
 
-  tibble::as_tibble(row[cols]) %>%
-    janitor::clean_names() %>%
-    make_hoopR_data("ESPN Basketball Player Core from ESPN.com", Sys.time())
+  .player_core_finalize(tibble::as_tibble(row[cols]))
 }
 
 #' The released column order. Order is part of the contract -- both pipelines
@@ -200,7 +198,17 @@ espn_basketball_player_core <- function(payload, athlete_id) {
   # The empty path is finalized identically to the populated one, so a caller
   # that chains on the result sees the same class and attributes whether or not
   # the payload had anything in it.
-  tibble::as_tibble(proto) %>%
+  .player_core_finalize(tibble::as_tibble(proto))
+}
+
+#' Apply the package data contract to a player_core frame.
+#'
+#' Both return paths go through here so they cannot drift: the type string in
+#' particular was previously written out twice, which is one edit away from the
+#' two paths disagreeing about what they claim to be.
+#' @noRd
+.player_core_finalize <- function(df) {
+  df %>%
     janitor::clean_names() %>%
     make_hoopR_data("ESPN Basketball Player Core from ESPN.com", Sys.time())
 }

--- a/R/espn_basketball_player_core.R
+++ b/R/espn_basketball_player_core.R
@@ -1,4 +1,7 @@
+#' **Project an ESPN core-v2 athlete record into a `player_core` row**
 #' @name espn_basketball_player_core
+NULL
+#' @rdname espn_basketball_player_core
 #' @aliases espn_basketball_player_core
 #' @title **Project an ESPN core-v2 athlete record into a `player_core` row**
 #' @description Turns one ESPN core-v2 `/athletes/{id}` payload into the single
@@ -85,6 +88,17 @@
 #'   )
 #'   espn_basketball_player_core(payload, athlete_id = 1966)
 #' }
+#' @section Twin:
+#' `wehoop::espn_basketball_player_core()` is the identical function for the
+#' women's leagues. The core-v2 athlete resource is the same payload shape for
+#' nba/wnba/mbb/wbb, so the projection is league-agnostic -- sdv-py implements
+#' it once and re-exports it per league. hoopR and wehoop are independently
+#' published and neither depends on the other, so here it is duplicated:
+#' **a change to one must land in the other in the same session, verified.**
+#' @author Saiem Gilani
+#' @importFrom tibble as_tibble
+#' @importFrom janitor clean_names
+#' @family Basketball Analytics Utilities
 #' @export
 espn_basketball_player_core <- function(payload, athlete_id) {
   cols <- .player_core_cols()
@@ -145,7 +159,9 @@ espn_basketball_player_core <- function(payload, athlete_id) {
     active = .pc_lgl(payload[["active"]])
   )
 
-  tibble::as_tibble(row[cols])
+  tibble::as_tibble(row[cols]) %>%
+    janitor::clean_names() %>%
+    make_hoopR_data("ESPN Basketball Player Core from ESPN.com", Sys.time())
 }
 
 #' The released column order. Order is part of the contract -- both pipelines
@@ -182,7 +198,12 @@ espn_basketball_player_core <- function(payload, athlete_id) {
     if (c %in% int_cols) integer() else if (c %in% dbl_cols) numeric() else if (c == "active") logical() else character()
   })
   names(proto) <- cols
-  tibble::as_tibble(proto)
+  # The empty path is finalized identically to the populated one, so a caller
+  # that chains on the result sees the same class and attributes whether or not
+  # the payload had anything in it.
+  tibble::as_tibble(proto) %>%
+    janitor::clean_names() %>%
+    make_hoopR_data("ESPN Basketball Player Core from ESPN.com", Sys.time())
 }
 
 #' A nested node, or an empty list when absent. Mirrors Python's

--- a/R/hoopshype_salaries.R
+++ b/R/hoopshype_salaries.R
@@ -1,7 +1,7 @@
 #' @title
 #' **HoopsHype Player Salaries**
 #' @description
-#' **Get NBA player salaries from [HoopsHype](https://hoopshype.com).**
+#' **Get NBA player salaries from [HoopsHype](https://www.hoopshype.com/).**
 #'
 #' Returns the full league's player salaries, one row per player per contract
 #' season (current plus future seasons HoopsHype lists). No API key is required;
@@ -73,7 +73,7 @@ hoopshype_salaries <- function() {
       rows <- list()
       for (slug in teams) {
         team_rows <- tryCatch({
-          doc <- .ext_html(paste0("https://hoopshype.com/salaries/", slug, "/"))
+          doc <- .ext_html(paste0("https://www.hoopshype.com/salaries/", slug, "/"))
           contracts <- contracts_of(.next_data(doc))
           do.call(c, lapply(contracts, function(ct) {
             pl <- ct$player

--- a/README.Rmd
+++ b/README.Rmd
@@ -109,8 +109,8 @@ For more information on the package and function reference, please see the  [**`
 <a href="https://x.com/theFirmAISports" target="blank"><img src="https://img.shields.io/twitter/follow/theFirmAISports?color=blue&label=%40theFirmAISports&logo=x&style=for-the-badge" alt="@theFirmAISports" /></a>
 <a href="https://github.com/papagorgio23" target="blank"><img src="https://img.shields.io/github/followers/papagorgio23?color=eee&logo=Github&style=for-the-badge" alt="@papagorgio23" /></a>
 
--   Billy Fryer (@_b4billy_)
-<a href="https://x.com/_b4billy_" target="blank"><img src="https://img.shields.io/twitter/follow/_b4billy_?color=blue&label=%40_b4billy_&logo=x&style=for-the-badge" alt="@_b4billy_" /></a>
+-   Billy Fryer (@BillyFriyer42)
+<a href="https://x.com/BillyFriyer42" target="blank"><img src="https://img.shields.io/twitter/follow/BillyFriyer42?color=blue&label=%40BillyFriyer42&logo=x&style=for-the-badge" alt="@BillyFriyer42" /></a>
 <a href="https://github.com/billyfryer" target="blank"><img src="https://img.shields.io/github/followers/billyfryer?color=eee&logo=Github&style=for-the-badge" alt="@billyfryer" /></a>
 
 -   Ross Drucker (@rossdrucker9)

--- a/README.Rmd
+++ b/README.Rmd
@@ -93,7 +93,7 @@ For more information on the package and function reference, please see the  [**`
 
 [![X Follow](https://img.shields.io/twitter/follow/SportsDataverse?color=blue&label=%40SportsDataverse&logo=x&style=for-the-badge)](https://x.com/SportsDataverse)
 
-[![GitHub stars](https://img.shields.io/github/stars/sportsdataverse/hoopR.svg?color=eee&logo=github&style=for-the-badge&label=Star%20hoopR&maxAge=2592000)](https://github.com/sportsdataverse/hoopR/stargazers/)
+[![GitHub stars](https://img.shields.io/github/stars/sportsdataverse/hoopR.svg?color=eee&logo=github&style=for-the-badge&label=Star%20hoopR&maxAge=2592000)](https://github.com/sportsdataverse/hoopR/stargazers)
 
 
 ## **Our Authors**

--- a/README.Rmd
+++ b/README.Rmd
@@ -109,8 +109,8 @@ For more information on the package and function reference, please see the  [**`
 <a href="https://x.com/theFirmAISports" target="blank"><img src="https://img.shields.io/twitter/follow/theFirmAISports?color=blue&label=%40theFirmAISports&logo=x&style=for-the-badge" alt="@theFirmAISports" /></a>
 <a href="https://github.com/papagorgio23" target="blank"><img src="https://img.shields.io/github/followers/papagorgio23?color=eee&logo=Github&style=for-the-badge" alt="@papagorgio23" /></a>
 
--   Billy Fryer (@BillyFriyer42)
-<a href="https://x.com/BillyFriyer42" target="blank"><img src="https://img.shields.io/twitter/follow/BillyFriyer42?color=blue&label=%40BillyFriyer42&logo=x&style=for-the-badge" alt="@BillyFriyer42" /></a>
+-   Billy Fryer (@BillyFryer42)
+<a href="https://x.com/BillyFryer42" target="blank"><img src="https://img.shields.io/twitter/follow/BillyFryer42?color=blue&label=%40BillyFryer42&logo=x&style=for-the-badge" alt="@BillyFryer42" /></a>
 <a href="https://github.com/billyfryer" target="blank"><img src="https://img.shields.io/github/followers/billyfryer?color=eee&logo=Github&style=for-the-badge" alt="@billyfryer" /></a>
 
 -   Ross Drucker (@rossdrucker9)

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ stars](https://img.shields.io/github/stars/sportsdataverse/hoopR.svg?color=eee&l
     <a href="https://github.com/papagorgio23" target="blank"><img src="https://img.shields.io/github/followers/papagorgio23?color=eee&logo=Github&style=for-the-badge" alt="@papagorgio23" /></a>
 
   - Billy Fryer (@\_b4billy\_)
-    <a href="https://x.com/BillyFriyer42" target="blank"><img src="https://img.shields.io/twitter/follow/BillyFriyer42?color=blue&label=%40BillyFriyer42&logo=x&style=for-the-badge" alt="@BillyFriyer42" /></a>
+    <a href="https://x.com/BillyFryer42" target="blank"><img src="https://img.shields.io/twitter/follow/BillyFryer42?color=blue&label=%40BillyFryer42&logo=x&style=for-the-badge" alt="@BillyFryer42" /></a>
     <a href="https://github.com/billyfryer" target="blank"><img src="https://img.shields.io/github/followers/billyfryer?color=eee&logo=Github&style=for-the-badge" alt="@billyfryer" /></a>
 
   - Ross Drucker (@rossdrucker9)

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Releases**](https://hoopR.sportsdataverse.org/news/index.html)
 Follow](https://img.shields.io/twitter/follow/SportsDataverse?color=blue&label=%40SportsDataverse&logo=x&style=for-the-badge)](https://x.com/SportsDataverse)
 
 [![GitHub
-stars](https://img.shields.io/github/stars/sportsdataverse/hoopR.svg?color=eee&logo=github&style=for-the-badge&label=Star%20hoopR&maxAge=2592000)](https://github.com/sportsdataverse/hoopR/stargazers/)
+stars](https://img.shields.io/github/stars/sportsdataverse/hoopR.svg?color=eee&logo=github&style=for-the-badge&label=Star%20hoopR&maxAge=2592000)](https://github.com/sportsdataverse/hoopR/stargazers)
 
 ## **Our Authors**
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ stars](https://img.shields.io/github/stars/sportsdataverse/hoopR.svg?color=eee&l
     <a href="https://github.com/papagorgio23" target="blank"><img src="https://img.shields.io/github/followers/papagorgio23?color=eee&logo=Github&style=for-the-badge" alt="@papagorgio23" /></a>
 
   - Billy Fryer (@\_b4billy\_)
-    <a href="https://x.com/_b4billy_" target="blank"><img src="https://img.shields.io/twitter/follow/_b4billy_?color=blue&label=%40_b4billy_&logo=x&style=for-the-badge" alt="@_b4billy_" /></a>
+    <a href="https://x.com/BillyFriyer42" target="blank"><img src="https://img.shields.io/twitter/follow/BillyFriyer42?color=blue&label=%40BillyFriyer42&logo=x&style=for-the-badge" alt="@BillyFriyer42" /></a>
     <a href="https://github.com/billyfryer" target="blank"><img src="https://img.shields.io/github/followers/billyfryer?color=eee&logo=Github&style=for-the-badge" alt="@billyfryer" /></a>
 
   - Ross Drucker (@rossdrucker9)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -42,7 +42,7 @@ authors:
   Jason Lee:
     href: https://x.com/theFirmAISports
   Billy Fryer:
-    href: https://x.com/_b4billy_
+    href: https://x.com/BillyFriyer42
   Ross Drucker:
     href: https://x.com/rossdrucker9
   Vladislav Shufinskiy:

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -200,6 +200,7 @@ reference:
       - '`load_nba_team_stats`'
       - '`load_nba_game_rosters`'
       - '`load_nba_officials`'
+      - '`load_nba_player_core`'
       - '`update_nba_db`'
   - subtitle: Men's College Basketball Data Functions
     desc: Functions exported by hoopR to access the hoopR-data repository's Men's College Basketball Data
@@ -214,6 +215,7 @@ reference:
       - '`load_mbb_team_stats`'
       - '`load_mbb_game_rosters`'
       - '`load_mbb_officials`'
+      - '`load_mbb_player_core`'
       - '`update_mbb_db`'
   - title: Cross-Source Crosswalks
   - subtitle: NBA Crosswalk Functions
@@ -279,6 +281,7 @@ reference:
       - '`nba_per_minutes`'
       - '`nba_per_possessions`'
       - '`nba_add_advanced_metrics`'
+      - '`espn_basketball_player_core`'
   - subtitle: NBA Dictionaries & Media
     desc: Player / team dictionaries and CDN headshot / logo URL helpers.
     contents:

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -42,7 +42,7 @@ authors:
   Jason Lee:
     href: https://x.com/theFirmAISports
   Billy Fryer:
-    href: https://x.com/BillyFriyer42
+    href: https://x.com/BillyFryer42
   Ross Drucker:
     href: https://x.com/rossdrucker9
   Vladislav Shufinskiy:

--- a/man/espn_basketball_player_core.Rd
+++ b/man/espn_basketball_player_core.Rd
@@ -97,10 +97,16 @@ published and neither depends on the other, so here it is duplicated:
 
 \examples{
 \donttest{
+  # Split across lines to keep the Rd under the line-width limit; the
+  # core-v2 $ref URLs are long enough to be truncated in the PDF manual.
+  team_ref <- paste0(
+    "http://sports.core.api.espn.com/v2/sports/basketball/",
+    "leagues/nba/seasons/2025/teams/22"
+  )
   payload <- list(
     guid = "abc", fullName = "Jane Doe", jersey = "23",
     position = list(id = "5", abbreviation = "G"),
-    team = list(`$ref` = "http://sports.core.api.espn.com/v2/sports/basketball/leagues/nba/seasons/2025/teams/22")
+    team = list(`$ref` = team_ref)
   )
   espn_basketball_player_core(payload, athlete_id = 1966)
 }

--- a/man/espn_basketball_player_core.Rd
+++ b/man/espn_basketball_player_core.Rd
@@ -85,6 +85,16 @@ against a golden fixture captured from that function; see
 \code{tests/testthat/fixtures/player_core/README.md} for provenance. Neither
 implementation is authoritative — a divergence is a review item.
 }
+\section{Twin}{
+
+\code{wehoop::espn_basketball_player_core()} is the identical function for the
+women's leagues. The core-v2 athlete resource is the same payload shape for
+nba/wnba/mbb/wbb, so the projection is league-agnostic -- sdv-py implements
+it once and re-exports it per league. hoopR and wehoop are independently
+published and neither depends on the other, so here it is duplicated:
+\strong{a change to one must land in the other in the same session, verified.}
+}
+
 \examples{
 \donttest{
   payload <- list(
@@ -95,3 +105,28 @@ implementation is authoritative — a divergence is a review item.
   espn_basketball_player_core(payload, athlete_id = 1966)
 }
 }
+\seealso{
+Other Basketball Analytics Utilities:
+\code{\link[=nba_add_advanced_metrics]{nba_add_advanced_metrics()}},
+\code{\link[=nba_assist_pct]{nba_assist_pct()}},
+\code{\link[=nba_assist_to_turnover]{nba_assist_to_turnover()}},
+\code{\link[=nba_defensive_rating]{nba_defensive_rating()}},
+\code{\link[=nba_effective_fg_pct]{nba_effective_fg_pct()}},
+\code{\link[=nba_four_factors]{nba_four_factors()}},
+\code{\link[=nba_ft_rate]{nba_ft_rate()}},
+\code{\link[=nba_game_score]{nba_game_score()}},
+\code{\link[=nba_net_rating]{nba_net_rating()}},
+\code{\link[=nba_offensive_rating]{nba_offensive_rating()}},
+\code{\link[=nba_oreb_pct]{nba_oreb_pct()}},
+\code{\link[=nba_pace]{nba_pace()}},
+\code{\link[=nba_per_minutes]{nba_per_minutes()}},
+\code{\link[=nba_per_possessions]{nba_per_possessions()}},
+\code{\link[=nba_possessions]{nba_possessions()}},
+\code{\link[=nba_true_shooting_pct]{nba_true_shooting_pct()}},
+\code{\link[=nba_turnover_pct]{nba_turnover_pct()}},
+\code{\link[=nba_usage_rate]{nba_usage_rate()}}
+}
+\author{
+Saiem Gilani
+}
+\concept{Basketball Analytics Utilities}

--- a/man/hoopshype_salaries.Rd
+++ b/man/hoopshype_salaries.Rd
@@ -25,7 +25,7 @@ A \code{hoopR_data} tibble with one row per player-season:\tabular{lll}{
 }
 }
 \description{
-\strong{Get NBA player salaries from \href{https://hoopshype.com}{HoopsHype}.}
+\strong{Get NBA player salaries from \href{https://www.hoopshype.com/}{HoopsHype}.}
 
 Returns the full league's player salaries, one row per player per contract
 season (current plus future seasons HoopsHype lists). No API key is required;

--- a/man/nba_add_advanced_metrics.Rd
+++ b/man/nba_add_advanced_metrics.Rd
@@ -28,6 +28,7 @@ nba_add_advanced_metrics(box)
 }
 \seealso{
 Other Basketball Analytics Utilities:
+\code{\link[=espn_basketball_player_core]{espn_basketball_player_core()}},
 \code{\link[=nba_assist_pct]{nba_assist_pct()}},
 \code{\link[=nba_assist_to_turnover]{nba_assist_to_turnover()}},
 \code{\link[=nba_defensive_rating]{nba_defensive_rating()}},

--- a/man/nba_assist_pct.Rd
+++ b/man/nba_assist_pct.Rd
@@ -23,6 +23,7 @@ nba_assist_pct(ast = 8, fgm = 10, minutes = 36, team_fgm = 40, team_minutes = 24
 }
 \seealso{
 Other Basketball Analytics Utilities:
+\code{\link[=espn_basketball_player_core]{espn_basketball_player_core()}},
 \code{\link[=nba_add_advanced_metrics]{nba_add_advanced_metrics()}},
 \code{\link[=nba_assist_to_turnover]{nba_assist_to_turnover()}},
 \code{\link[=nba_defensive_rating]{nba_defensive_rating()}},

--- a/man/nba_assist_to_turnover.Rd
+++ b/man/nba_assist_to_turnover.Rd
@@ -20,6 +20,7 @@ nba_assist_to_turnover(ast = 8, tov = 3)
 }
 \seealso{
 Other Basketball Analytics Utilities:
+\code{\link[=espn_basketball_player_core]{espn_basketball_player_core()}},
 \code{\link[=nba_add_advanced_metrics]{nba_add_advanced_metrics()}},
 \code{\link[=nba_assist_pct]{nba_assist_pct()}},
 \code{\link[=nba_defensive_rating]{nba_defensive_rating()}},

--- a/man/nba_defensive_rating.Rd
+++ b/man/nba_defensive_rating.Rd
@@ -20,6 +20,7 @@ nba_defensive_rating(opp_pts = 108, poss = 100)
 }
 \seealso{
 Other Basketball Analytics Utilities:
+\code{\link[=espn_basketball_player_core]{espn_basketball_player_core()}},
 \code{\link[=nba_add_advanced_metrics]{nba_add_advanced_metrics()}},
 \code{\link[=nba_assist_pct]{nba_assist_pct()}},
 \code{\link[=nba_assist_to_turnover]{nba_assist_to_turnover()}},

--- a/man/nba_effective_fg_pct.Rd
+++ b/man/nba_effective_fg_pct.Rd
@@ -21,6 +21,7 @@ nba_effective_fg_pct(fgm = 10, fg3m = 4, fga = 20)
 }
 \seealso{
 Other Basketball Analytics Utilities:
+\code{\link[=espn_basketball_player_core]{espn_basketball_player_core()}},
 \code{\link[=nba_add_advanced_metrics]{nba_add_advanced_metrics()}},
 \code{\link[=nba_assist_pct]{nba_assist_pct()}},
 \code{\link[=nba_assist_to_turnover]{nba_assist_to_turnover()}},

--- a/man/nba_four_factors.Rd
+++ b/man/nba_four_factors.Rd
@@ -25,6 +25,7 @@ nba_four_factors(fgm = 40, fg3m = 12, fga = 88, fta = 25, ftm = 20,
 }
 \seealso{
 Other Basketball Analytics Utilities:
+\code{\link[=espn_basketball_player_core]{espn_basketball_player_core()}},
 \code{\link[=nba_add_advanced_metrics]{nba_add_advanced_metrics()}},
 \code{\link[=nba_assist_pct]{nba_assist_pct()}},
 \code{\link[=nba_assist_to_turnover]{nba_assist_to_turnover()}},

--- a/man/nba_ft_rate.Rd
+++ b/man/nba_ft_rate.Rd
@@ -20,6 +20,7 @@ nba_ft_rate(fta = 8, fga = 20)
 }
 \seealso{
 Other Basketball Analytics Utilities:
+\code{\link[=espn_basketball_player_core]{espn_basketball_player_core()}},
 \code{\link[=nba_add_advanced_metrics]{nba_add_advanced_metrics()}},
 \code{\link[=nba_assist_pct]{nba_assist_pct()}},
 \code{\link[=nba_assist_to_turnover]{nba_assist_to_turnover()}},

--- a/man/nba_game_score.Rd
+++ b/man/nba_game_score.Rd
@@ -22,6 +22,7 @@ nba_game_score(pts = 30, fgm = 10, fga = 20, fta = 8, ftm = 7,
 }
 \seealso{
 Other Basketball Analytics Utilities:
+\code{\link[=espn_basketball_player_core]{espn_basketball_player_core()}},
 \code{\link[=nba_add_advanced_metrics]{nba_add_advanced_metrics()}},
 \code{\link[=nba_assist_pct]{nba_assist_pct()}},
 \code{\link[=nba_assist_to_turnover]{nba_assist_to_turnover()}},

--- a/man/nba_net_rating.Rd
+++ b/man/nba_net_rating.Rd
@@ -20,6 +20,7 @@ nba_net_rating(off_rating = 115, def_rating = 108)
 }
 \seealso{
 Other Basketball Analytics Utilities:
+\code{\link[=espn_basketball_player_core]{espn_basketball_player_core()}},
 \code{\link[=nba_add_advanced_metrics]{nba_add_advanced_metrics()}},
 \code{\link[=nba_assist_pct]{nba_assist_pct()}},
 \code{\link[=nba_assist_to_turnover]{nba_assist_to_turnover()}},

--- a/man/nba_offensive_rating.Rd
+++ b/man/nba_offensive_rating.Rd
@@ -20,6 +20,7 @@ nba_offensive_rating(pts = 115, poss = 100)
 }
 \seealso{
 Other Basketball Analytics Utilities:
+\code{\link[=espn_basketball_player_core]{espn_basketball_player_core()}},
 \code{\link[=nba_add_advanced_metrics]{nba_add_advanced_metrics()}},
 \code{\link[=nba_assist_pct]{nba_assist_pct()}},
 \code{\link[=nba_assist_to_turnover]{nba_assist_to_turnover()}},

--- a/man/nba_oreb_pct.Rd
+++ b/man/nba_oreb_pct.Rd
@@ -20,6 +20,7 @@ nba_oreb_pct(oreb = 10, opp_dreb = 33)
 }
 \seealso{
 Other Basketball Analytics Utilities:
+\code{\link[=espn_basketball_player_core]{espn_basketball_player_core()}},
 \code{\link[=nba_add_advanced_metrics]{nba_add_advanced_metrics()}},
 \code{\link[=nba_assist_pct]{nba_assist_pct()}},
 \code{\link[=nba_assist_to_turnover]{nba_assist_to_turnover()}},

--- a/man/nba_pace.Rd
+++ b/man/nba_pace.Rd
@@ -23,6 +23,7 @@ nba_pace(poss = 100, minutes = 240)
 }
 \seealso{
 Other Basketball Analytics Utilities:
+\code{\link[=espn_basketball_player_core]{espn_basketball_player_core()}},
 \code{\link[=nba_add_advanced_metrics]{nba_add_advanced_metrics()}},
 \code{\link[=nba_assist_pct]{nba_assist_pct()}},
 \code{\link[=nba_assist_to_turnover]{nba_assist_to_turnover()}},

--- a/man/nba_per_minutes.Rd
+++ b/man/nba_per_minutes.Rd
@@ -31,6 +31,7 @@ nba_per_minutes(box, cols = c("pts", "reb", "ast"))
 }
 \seealso{
 Other Basketball Analytics Utilities:
+\code{\link[=espn_basketball_player_core]{espn_basketball_player_core()}},
 \code{\link[=nba_add_advanced_metrics]{nba_add_advanced_metrics()}},
 \code{\link[=nba_assist_pct]{nba_assist_pct()}},
 \code{\link[=nba_assist_to_turnover]{nba_assist_to_turnover()}},

--- a/man/nba_per_possessions.Rd
+++ b/man/nba_per_possessions.Rd
@@ -29,6 +29,7 @@ nba_per_possessions(box, cols = c("pts", "tov"))
 }
 \seealso{
 Other Basketball Analytics Utilities:
+\code{\link[=espn_basketball_player_core]{espn_basketball_player_core()}},
 \code{\link[=nba_add_advanced_metrics]{nba_add_advanced_metrics()}},
 \code{\link[=nba_assist_pct]{nba_assist_pct()}},
 \code{\link[=nba_assist_to_turnover]{nba_assist_to_turnover()}},

--- a/man/nba_possessions.Rd
+++ b/man/nba_possessions.Rd
@@ -22,6 +22,7 @@ nba_possessions(fga = 88, fta = 25, oreb = 10, tov = 13)
 }
 \seealso{
 Other Basketball Analytics Utilities:
+\code{\link[=espn_basketball_player_core]{espn_basketball_player_core()}},
 \code{\link[=nba_add_advanced_metrics]{nba_add_advanced_metrics()}},
 \code{\link[=nba_assist_pct]{nba_assist_pct()}},
 \code{\link[=nba_assist_to_turnover]{nba_assist_to_turnover()}},

--- a/man/nba_true_shooting_pct.Rd
+++ b/man/nba_true_shooting_pct.Rd
@@ -21,6 +21,7 @@ nba_true_shooting_pct(pts = 30, fga = 20, fta = 8)
 }
 \seealso{
 Other Basketball Analytics Utilities:
+\code{\link[=espn_basketball_player_core]{espn_basketball_player_core()}},
 \code{\link[=nba_add_advanced_metrics]{nba_add_advanced_metrics()}},
 \code{\link[=nba_assist_pct]{nba_assist_pct()}},
 \code{\link[=nba_assist_to_turnover]{nba_assist_to_turnover()}},

--- a/man/nba_turnover_pct.Rd
+++ b/man/nba_turnover_pct.Rd
@@ -20,6 +20,7 @@ nba_turnover_pct(tov = 13, fga = 88, fta = 25)
 }
 \seealso{
 Other Basketball Analytics Utilities:
+\code{\link[=espn_basketball_player_core]{espn_basketball_player_core()}},
 \code{\link[=nba_add_advanced_metrics]{nba_add_advanced_metrics()}},
 \code{\link[=nba_assist_pct]{nba_assist_pct()}},
 \code{\link[=nba_assist_to_turnover]{nba_assist_to_turnover()}},

--- a/man/nba_usage_rate.Rd
+++ b/man/nba_usage_rate.Rd
@@ -32,6 +32,7 @@ nba_usage_rate(fga = 20, fta = 8, tov = 3, minutes = 36,
 }
 \seealso{
 Other Basketball Analytics Utilities:
+\code{\link[=espn_basketball_player_core]{espn_basketball_player_core()}},
 \code{\link[=nba_add_advanced_metrics]{nba_add_advanced_metrics()}},
 \code{\link[=nba_assist_pct]{nba_assist_pct()}},
 \code{\link[=nba_assist_to_turnover]{nba_assist_to_turnover()}},

--- a/tests/testthat/test-espn_basketball_player_core.R
+++ b/tests/testthat/test-espn_basketball_player_core.R
@@ -92,7 +92,7 @@ test_that("espn_basketball_player_core() reproduces the sdv-py oracle", {
 
 test_that("espn_basketball_player_core() covers the branches the fixtures encode", {
   fx <- testthat::test_path("fixtures", "player_core")
-  read_one <- function(aid) {
+  .read_one <- function(aid) {
     espn_basketball_player_core(
       jsonlite::fromJSON(file.path(fx, paste0(aid, ".json")), simplifyVector = FALSE),
       athlete_id = aid
@@ -100,13 +100,13 @@ test_that("espn_basketball_player_core() covers the branches the fixtures encode
   }
 
   # 1011 has no college node: college_id must be NA, not 0 and not an error.
-  expect_true(is.na(read_one(1011L)$college_id))
+  expect_true(is.na(.read_one(1011L)$college_id))
   # 10 has a college but no draft: all three draft columns NA together.
-  no_draft <- read_one(10L)
+  no_draft <- .read_one(10L)
   expect_true(all(is.na(c(no_draft$draft_year, no_draft$draft_round, no_draft$draft_selection))))
   expect_false(is.na(no_draft$college_id))
   # 1000 is the fully-populated path.
-  full <- read_one(1000L)
+  full <- .read_one(1000L)
   expect_false(is.na(full$college_id))
   expect_false(is.na(full$draft_year))
 })

--- a/tests/testthat/test-espn_basketball_player_core.R
+++ b/tests/testthat/test-espn_basketball_player_core.R
@@ -186,3 +186,27 @@ test_that("espn_basketball_player_core() keeps athlete_id an integer join key", 
   expect_equal(out$athlete_id, 1966L)
   expect_false(is.character(out$athlete_id))
 })
+
+test_that("espn_basketball_player_core() finalizes both paths as hoopR_data", {
+  # Without these assertions the suite passes even if make_hoopR_data() is deleted: the
+  # golden-master test compares values and column names, and neither changes
+  # when the class and attributes are dropped. The finalized contract was added
+  # in response to review, so it needs a test that fails when it regresses.
+  fx <- testthat::test_path("fixtures", "player_core")
+  populated <- espn_basketball_player_core(
+    jsonlite::fromJSON(file.path(fx, "1000.json"), simplifyVector = FALSE),
+    athlete_id = 1000L
+  )
+  empty <- espn_basketball_player_core(list(), athlete_id = 1L)
+
+  for (out in list(populated, empty)) {
+    expect_s3_class(out, "hoopR_data")
+    expect_equal(attr(out, "hoopR_type"),
+                 "ESPN Basketball Player Core from ESPN.com")
+    expect_s3_class(attr(out, "hoopR_timestamp"), "POSIXct")
+    # The finalizer must not disturb the 35-column contract it wraps.
+    expect_equal(ncol(out), 35L)
+  }
+  expect_equal(nrow(populated), 1L)
+  expect_equal(nrow(empty), 0L)
+})

--- a/vignettes/getting-started-hoopR.Rmd
+++ b/vignettes/getting-started-hoopR.Rmd
@@ -169,8 +169,8 @@ dplyr::glimpse(mbb_player_box)
 <a href="https://x.com/theFirmAISports" target="blank"><img src="https://img.shields.io/twitter/follow/theFirmAISports?color=blue&label=%40theFirmAISports&logo=x&style=for-the-badge" alt="@theFirmAISports" /></a>
 <a href="https://github.com/papagorgio23" target="blank"><img src="https://img.shields.io/github/followers/papagorgio23?color=eee&logo=Github&style=for-the-badge" alt="@papagorgio23" /></a>
 
--   [Billy Fryer](https://x.com/_b4billy_)
-<a href="https://x.com/_b4billy_" target="blank"><img src="https://img.shields.io/twitter/follow/_b4billy_?color=blue&label=%40_b4billy_&logo=x&style=for-the-badge" alt="@_b4billy_" /></a>
+-   [Billy Fryer](https://x.com/BillyFriyer42)
+<a href="https://x.com/BillyFriyer42" target="blank"><img src="https://img.shields.io/twitter/follow/BillyFriyer42?color=blue&label=%40BillyFriyer42&logo=x&style=for-the-badge" alt="@BillyFriyer42" /></a>
 <a href="https://github.com/billyfryer" target="blank"><img src="https://img.shields.io/github/followers/billyfryer?color=eee&logo=Github&style=for-the-badge" alt="@billyfryer" /></a>
 
 -   [Ross Drucker](https://x.com/rossdrucker9)

--- a/vignettes/getting-started-hoopR.Rmd
+++ b/vignettes/getting-started-hoopR.Rmd
@@ -169,8 +169,8 @@ dplyr::glimpse(mbb_player_box)
 <a href="https://x.com/theFirmAISports" target="blank"><img src="https://img.shields.io/twitter/follow/theFirmAISports?color=blue&label=%40theFirmAISports&logo=x&style=for-the-badge" alt="@theFirmAISports" /></a>
 <a href="https://github.com/papagorgio23" target="blank"><img src="https://img.shields.io/github/followers/papagorgio23?color=eee&logo=Github&style=for-the-badge" alt="@papagorgio23" /></a>
 
--   [Billy Fryer](https://x.com/BillyFriyer42)
-<a href="https://x.com/BillyFriyer42" target="blank"><img src="https://img.shields.io/twitter/follow/BillyFriyer42?color=blue&label=%40BillyFriyer42&logo=x&style=for-the-badge" alt="@BillyFriyer42" /></a>
+-   [Billy Fryer](https://x.com/BillyFryer42)
+<a href="https://x.com/BillyFryer42" target="blank"><img src="https://img.shields.io/twitter/follow/BillyFryer42?color=blue&label=%40BillyFryer42&logo=x&style=for-the-badge" alt="@BillyFryer42" /></a>
 <a href="https://github.com/billyfryer" target="blank"><img src="https://img.shields.io/github/followers/billyfryer?color=eee&logo=Github&style=for-the-badge" alt="@billyfryer" /></a>
 
 -   [Ross Drucker](https://x.com/rossdrucker9)


### PR DESCRIPTION
Post-merge follow-up to #200, from the CodeRabbit review and a local R CMD
check + pkgdown check. Each finding was verified against current code before
acting; one is declined with a reason.

ACCEPTED

  * Roxygen completeness. Added the house pattern from CLAUDE.md that this
    function was missing: a `@name` block with its NULL object, `@rdname`,
    `@author`, `@importFrom`, and `@family Basketball Analytics Utilities` --
    whose pkgdown description ("no network calls; league-agnostic") describes
    this function exactly.

  * Finalize both return paths. Every returned data frame in this package goes
    through janitor::clean_names() then make_hoopR_data(); this one returned a
    bare tibble. Applied to the populated AND the empty path, so a caller
    chaining on the result sees the same class and attributes either way.
    clean_names() is a no-op on these names by construction -- the parity test
    asserts the exact 35-column contract and still passes 59/59.

  * Test helper renamed read_one -> .read_one (internal-helper convention).

DECLINED

  * "Assert names(expected) is a subset of names(actual) rather than exact
    equality." Column ORDER is part of this contract -- both pipelines feed one
    parquet and some consumers select positionally, which the test comments
    already state. A subset assertion would stop catching a reordering, which
    is precisely the regression worth catching. CodeRabbit allows this
    exception ("only if positional order is part of the contract"); it is.

ALSO FIXED (found by the local gates, not the bots)

  * pkgdown was broken on main: check_pkgdown() failed with load_nba_player_core
    and load_mbb_player_core missing from the reference index. Both landed in
    #199 on 2026-07-17 without an index entry, so any pkgdown build has failed
    since. Added beside their sibling loaders. check_pkgdown() now passes.

  * .Rbuildignore did not cover the agent/tool directories (.omc, .remember,
    .ruff_cache, .pytest_cache, .understand-anything, .superpowers), so a LOCAL
    R CMD build swept them in and produced a "hidden files and directories"
    NOTE. CI never saw it because a fresh checkout has none of them -- which is
    exactly why it went unnoticed.

Verified: parity test 59/59, roxygen clean (0 warnings), pkgdown
check_pkgdown() passes.

## Summary by Sourcery

Standardize espn_basketball_player_core outputs and repair documentation and pkgdown indexing so player core loaders and analytics utilities are consistently exposed and build cleanly.

Bug Fixes:
- Fix pkgdown reference index so nba and mbb player core loader functions and espn_basketball_player_core are included and pkgdown builds succeed.
- Extend .Rbuildignore to exclude local agent/tool cache directories and eliminate hidden files/directories NOTES in R CMD build.

Enhancements:
- Finalize espn_basketball_player_core to always return hoopR-standard cleaned data frames for both populated and empty payload paths.
- Improve roxygen and Rd metadata for espn_basketball_player_core, including twin wehoop notice, family classification, author tag, and cross-links from Basketball Analytics Utilities docs.

Build:
- Update .Rbuildignore to ignore development agent and tool cache directories to keep build artifacts clean.

Documentation:
- Add detailed documentation and cross-references for espn_basketball_player_core within the Basketball Analytics Utilities family, including its relationship to wehoop and links from other analytics helpers.

Tests:
- Rename the espn_basketball_player_core test helper to follow internal helper naming conventions without changing test coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency when preparing populated and empty basketball player results.
  - Standardized player names, metadata, and timestamps.

- **Documentation**
  - Expanded reference navigation and cross-links for player data and analytics tools.
  - Added guidance for equivalent women’s-league functionality.
  - Updated salary-source, contributor, and project links.

- **Chores**
  - Updated ignore settings for logs and supported tooling.
  - Corrected HoopsHype and project badge URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->