### PR TITLE
fix(db): forward dots, perform documented writes, and repair the hoopR_data class vector

### DIFF
--- a/R/load_crosswalk.R
+++ b/R/load_crosswalk.R
@@ -38,7 +38,7 @@
       timestamp = attr(chunks[[meta_idx]], "hoopR_timestamp")
     )
   } else {
-    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
   }
   out
 }

--- a/R/load_crosswalk.R
+++ b/R/load_crosswalk.R
@@ -22,6 +22,12 @@
   if (is_installed("progressr")) p <- progressr::progressor(along = seasons)
 
   chunks <- lapply(urls, progressively(loader, p))
+  .bind_crosswalk_chunks(chunks)
+}
+
+#' Bind crosswalk chunks and apply the public hoopR_data class
+#' @noRd
+.bind_crosswalk_chunks <- function(chunks) {
   meta_idx <- tail(which(vapply(
     chunks,
     function(x) {

--- a/R/load_mbb.R
+++ b/R/load_mbb.R
@@ -84,7 +84,6 @@ load_mbb_pbp <- function(
     tablename = NULL) {
   old <- options(list(stringsAsFactors = FALSE, scipen = 999))
   on.exit(options(old))
-  dots <- rlang::dots_list(...)
   loader <- rds_from_url
   if (!is.null(dbConnection) && !is.null(tablename)) {
     in_db <- TRUE
@@ -116,7 +115,7 @@ load_mbb_pbp <- function(
   out <- lapply(urls, progressively(loader, p))
   out <- rbindlist_with_attrs(out)
   if (in_db) {
-    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE)
+    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
     class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
@@ -194,7 +193,6 @@ load_mbb_team_box <- function(
     tablename = NULL) {
   old <- options(list(stringsAsFactors = FALSE, scipen = 999))
   on.exit(options(old))
-  dots <- rlang::dots_list(...)
   loader <- rds_from_url
 
   if (!is.null(dbConnection) && !is.null(tablename)) {
@@ -226,7 +224,7 @@ load_mbb_team_box <- function(
   out <- lapply(urls, progressively(loader, p))
   out <- rbindlist_with_attrs(out)
   if (in_db) {
-    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE)
+    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
     class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
@@ -320,7 +318,6 @@ load_mbb_player_box <- function(
     tablename = NULL) {
   old <- options(list(stringsAsFactors = FALSE, scipen = 999))
   on.exit(options(old))
-  dots <- rlang::dots_list(...)
   loader <- rds_from_url
 
   if (!is.null(dbConnection) && !is.null(tablename)) {
@@ -352,7 +349,7 @@ load_mbb_player_box <- function(
   out <- lapply(urls, progressively(loader, p))
   out <- rbindlist_with_attrs(out)
   if (in_db) {
-    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE)
+    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
     class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
@@ -464,7 +461,6 @@ load_mbb_schedule <- function(
     tablename = NULL) {
   old <- options(list(stringsAsFactors = FALSE, scipen = 999))
   on.exit(options(old))
-  dots <- rlang::dots_list(...)
 
   loader <- rds_from_url
 
@@ -497,7 +493,7 @@ load_mbb_schedule <- function(
   out <- lapply(urls, progressively(loader, p))
   out <- rbindlist_with_attrs(out)
   if (in_db) {
-    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE)
+    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
     class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")

--- a/R/load_mbb.R
+++ b/R/load_mbb.R
@@ -757,7 +757,6 @@ load_mbb_rosters <- function(seasons = most_recent_mbb_season(), ...,
                                  dbConnection = NULL, tablename = NULL) {
   old <- options(list(stringsAsFactors = FALSE, scipen = 999))
   on.exit(options(old))
-  dots <- rlang::dots_list(...)
 
   loader <- rds_from_url
   if (!is.null(dbConnection) && !is.null(tablename)) in_db <- TRUE else in_db <- FALSE
@@ -777,7 +776,12 @@ load_mbb_rosters <- function(seasons = most_recent_mbb_season(), ...,
 
   out <- lapply(urls, progressively(loader, p))
   out <- rbindlist_with_attrs(out)
-  class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  if (in_db) {
+    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
+    out <- NULL
+  } else {
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  }
   out
 }
 
@@ -800,7 +804,6 @@ load_mbb_player_stats <- function(seasons = most_recent_mbb_season(), ...,
                                  dbConnection = NULL, tablename = NULL) {
   old <- options(list(stringsAsFactors = FALSE, scipen = 999))
   on.exit(options(old))
-  dots <- rlang::dots_list(...)
 
   loader <- rds_from_url
   if (!is.null(dbConnection) && !is.null(tablename)) in_db <- TRUE else in_db <- FALSE
@@ -820,7 +823,12 @@ load_mbb_player_stats <- function(seasons = most_recent_mbb_season(), ...,
 
   out <- lapply(urls, progressively(loader, p))
   out <- rbindlist_with_attrs(out)
-  class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  if (in_db) {
+    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
+    out <- NULL
+  } else {
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  }
   out
 }
 
@@ -843,7 +851,6 @@ load_mbb_team_stats <- function(seasons = most_recent_mbb_season(), ...,
                                  dbConnection = NULL, tablename = NULL) {
   old <- options(list(stringsAsFactors = FALSE, scipen = 999))
   on.exit(options(old))
-  dots <- rlang::dots_list(...)
 
   loader <- rds_from_url
   if (!is.null(dbConnection) && !is.null(tablename)) in_db <- TRUE else in_db <- FALSE
@@ -863,7 +870,12 @@ load_mbb_team_stats <- function(seasons = most_recent_mbb_season(), ...,
 
   out <- lapply(urls, progressively(loader, p))
   out <- rbindlist_with_attrs(out)
-  class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  if (in_db) {
+    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
+    out <- NULL
+  } else {
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  }
   out
 }
 
@@ -886,7 +898,6 @@ load_mbb_standings <- function(seasons = most_recent_mbb_season(), ...,
                                  dbConnection = NULL, tablename = NULL) {
   old <- options(list(stringsAsFactors = FALSE, scipen = 999))
   on.exit(options(old))
-  dots <- rlang::dots_list(...)
 
   loader <- rds_from_url
   if (!is.null(dbConnection) && !is.null(tablename)) in_db <- TRUE else in_db <- FALSE
@@ -906,7 +917,12 @@ load_mbb_standings <- function(seasons = most_recent_mbb_season(), ...,
 
   out <- lapply(urls, progressively(loader, p))
   out <- rbindlist_with_attrs(out)
-  class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  if (in_db) {
+    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
+    out <- NULL
+  } else {
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  }
   out
 }
 
@@ -929,7 +945,6 @@ load_mbb_game_rosters <- function(seasons = most_recent_mbb_season(), ...,
                                  dbConnection = NULL, tablename = NULL) {
   old <- options(list(stringsAsFactors = FALSE, scipen = 999))
   on.exit(options(old))
-  dots <- rlang::dots_list(...)
 
   loader <- rds_from_url
   if (!is.null(dbConnection) && !is.null(tablename)) in_db <- TRUE else in_db <- FALSE
@@ -949,7 +964,12 @@ load_mbb_game_rosters <- function(seasons = most_recent_mbb_season(), ...,
 
   out <- lapply(urls, progressively(loader, p))
   out <- rbindlist_with_attrs(out)
-  class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  if (in_db) {
+    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
+    out <- NULL
+  } else {
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  }
   out
 }
 
@@ -972,7 +992,6 @@ load_mbb_officials <- function(seasons = most_recent_mbb_season(), ...,
                                  dbConnection = NULL, tablename = NULL) {
   old <- options(list(stringsAsFactors = FALSE, scipen = 999))
   on.exit(options(old))
-  dots <- rlang::dots_list(...)
 
   loader <- rds_from_url
   if (!is.null(dbConnection) && !is.null(tablename)) in_db <- TRUE else in_db <- FALSE
@@ -992,7 +1011,12 @@ load_mbb_officials <- function(seasons = most_recent_mbb_season(), ...,
 
   out <- lapply(urls, progressively(loader, p))
   out <- rbindlist_with_attrs(out)
-  class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  if (in_db) {
+    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
+    out <- NULL
+  } else {
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  }
   out
 }
 
@@ -1031,7 +1055,6 @@ load_mbb_player_core <- function(seasons = most_recent_mbb_season(), ...,
                                  dbConnection = NULL, tablename = NULL) {
   old <- options(list(stringsAsFactors = FALSE, scipen = 999))
   on.exit(options(old))
-  dots <- rlang::dots_list(...)
 
   loader <- rds_from_url
   if (!is.null(dbConnection) && !is.null(tablename)) in_db <- TRUE else in_db <- FALSE
@@ -1051,6 +1074,11 @@ load_mbb_player_core <- function(seasons = most_recent_mbb_season(), ...,
 
   out <- lapply(urls, progressively(loader, p))
   out <- rbindlist_with_attrs(out)
-  class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  if (in_db) {
+    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
+    out <- NULL
+  } else {
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  }
   out
 }

--- a/R/load_mbb.R
+++ b/R/load_mbb.R
@@ -118,7 +118,7 @@ load_mbb_pbp <- function(
     DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
-    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
   }
   out
 }
@@ -227,7 +227,7 @@ load_mbb_team_box <- function(
     DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
-    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
   }
   out
 }
@@ -352,7 +352,7 @@ load_mbb_player_box <- function(
     DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
-    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
   }
   out
 }
@@ -496,7 +496,7 @@ load_mbb_schedule <- function(
     DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
-    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
   }
   out
 }
@@ -780,7 +780,7 @@ load_mbb_rosters <- function(seasons = most_recent_mbb_season(), ...,
     DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
-    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
   }
   out
 }
@@ -827,7 +827,7 @@ load_mbb_player_stats <- function(seasons = most_recent_mbb_season(), ...,
     DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
-    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
   }
   out
 }
@@ -874,7 +874,7 @@ load_mbb_team_stats <- function(seasons = most_recent_mbb_season(), ...,
     DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
-    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
   }
   out
 }
@@ -921,7 +921,7 @@ load_mbb_standings <- function(seasons = most_recent_mbb_season(), ...,
     DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
-    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
   }
   out
 }
@@ -968,7 +968,7 @@ load_mbb_game_rosters <- function(seasons = most_recent_mbb_season(), ...,
     DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
-    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
   }
   out
 }
@@ -1015,7 +1015,7 @@ load_mbb_officials <- function(seasons = most_recent_mbb_season(), ...,
     DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
-    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
   }
   out
 }
@@ -1078,7 +1078,7 @@ load_mbb_player_core <- function(seasons = most_recent_mbb_season(), ...,
     DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
-    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
   }
   out
 }

--- a/R/load_nba.R
+++ b/R/load_nba.R
@@ -86,7 +86,6 @@ load_nba_pbp <- function(seasons = most_recent_nba_season(), ...,
                          dbConnection = NULL, tablename = NULL) {
   old <- options(list(stringsAsFactors = FALSE, scipen = 999))
   on.exit(options(old))
-  dots <- rlang::dots_list(...)
 
   loader <- rds_from_url
 
@@ -108,7 +107,7 @@ load_nba_pbp <- function(seasons = most_recent_nba_season(), ...,
   out <- lapply(urls, progressively(loader, p))
   out <- rbindlist_with_attrs(out)
   if (in_db) {
-    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE)
+    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
     class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
@@ -313,7 +312,6 @@ load_nba_player_box <- function(seasons = most_recent_nba_season(), ...,
                                 dbConnection = NULL, tablename = NULL) {
   old <- options(list(stringsAsFactors = FALSE, scipen = 999))
   on.exit(options(old))
-  dots <- rlang::dots_list(...)
   loader <- rds_from_url
   if (!is.null(dbConnection) && !is.null(tablename)) in_db <- TRUE else in_db <- FALSE
 
@@ -333,7 +331,7 @@ load_nba_player_box <- function(seasons = most_recent_nba_season(), ...,
   out <- lapply(urls, progressively(loader, p))
   out <- rbindlist_with_attrs(out)
   if (in_db) {
-    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE)
+    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
     class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
@@ -437,7 +435,6 @@ load_nba_schedule <- function(seasons = most_recent_nba_season(), ...,
                               dbConnection = NULL, tablename = NULL) {
   old <- options(list(stringsAsFactors = FALSE, scipen = 999))
   on.exit(options(old))
-  dots <- rlang::dots_list(...)
 
   loader <- rds_from_url
   if (!is.null(dbConnection) && !is.null(tablename)) in_db <- TRUE else in_db <- FALSE
@@ -458,7 +455,7 @@ load_nba_schedule <- function(seasons = most_recent_nba_season(), ...,
   out <- lapply(urls, progressively(loader, p))
   out <- rbindlist_with_attrs(out)
   if (in_db) {
-    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE)
+    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
     class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")

--- a/R/load_nba.R
+++ b/R/load_nba.R
@@ -110,7 +110,7 @@ load_nba_pbp <- function(seasons = most_recent_nba_season(), ...,
     DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
-    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
   }
   out
 }
@@ -224,7 +224,7 @@ load_nba_team_box <- function(seasons = most_recent_nba_season(), ...,
     DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
-    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
   }
   out
 }
@@ -338,7 +338,7 @@ load_nba_player_box <- function(seasons = most_recent_nba_season(), ...,
     DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
-    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
   }
   out
 }
@@ -462,7 +462,7 @@ load_nba_schedule <- function(seasons = most_recent_nba_season(), ...,
     DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
-    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
   }
   out
 }
@@ -692,7 +692,7 @@ load_nba_standings <- function(seasons = most_recent_nba_season(), ...,
     DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
-    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
   }
   out
 }
@@ -741,7 +741,7 @@ load_nba_game_rosters <- function(seasons = most_recent_nba_season(), ...,
     DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
-    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
   }
   out
 }
@@ -790,7 +790,7 @@ load_nba_officials <- function(seasons = most_recent_nba_season(), ...,
     DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
-    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
   }
   out
 }
@@ -838,7 +838,7 @@ load_nba_draft <- function(seasons = most_recent_nba_season(), ...,
     DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
-    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
   }
   out
 }
@@ -886,7 +886,7 @@ load_nba_player_stats <- function(seasons = most_recent_nba_season(), ...,
     DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
-    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
   }
   out
 }
@@ -934,7 +934,7 @@ load_nba_team_stats <- function(seasons = most_recent_nba_season(), ...,
     DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
-    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
   }
   out
 }
@@ -983,7 +983,7 @@ load_nba_rosters <- function(seasons = most_recent_nba_season(), ...,
     DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
-    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
   }
   out
 }
@@ -1046,7 +1046,7 @@ load_nba_player_core <- function(seasons = most_recent_nba_season(), ...,
     DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
     out <- NULL
   } else {
-    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
   }
   out
 }

--- a/R/load_nba.R
+++ b/R/load_nba.R
@@ -201,7 +201,6 @@ load_nba_team_box <- function(seasons = most_recent_nba_season(), ...,
                               dbConnection = NULL, tablename = NULL) {
   old <- options(list(stringsAsFactors = FALSE, scipen = 999))
   on.exit(options(old))
-  dots <- rlang::dots_list(...)
 
   loader <- rds_from_url
   if (!is.null(dbConnection) && !is.null(tablename)) in_db <- TRUE else in_db <- FALSE
@@ -221,7 +220,12 @@ load_nba_team_box <- function(seasons = most_recent_nba_season(), ...,
 
   out <- lapply(urls, progressively(loader, p))
   out <- rbindlist_with_attrs(out)
-  class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  if (in_db) {
+    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
+    out <- NULL
+  } else {
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  }
   out
 }
 
@@ -665,7 +669,6 @@ load_nba_standings <- function(seasons = most_recent_nba_season(), ...,
                                dbConnection = NULL, tablename = NULL) {
   old <- options(list(stringsAsFactors = FALSE, scipen = 999))
   on.exit(options(old))
-  dots <- rlang::dots_list(...)
 
   loader <- rds_from_url
   if (!is.null(dbConnection) && !is.null(tablename)) in_db <- TRUE else in_db <- FALSE
@@ -685,7 +688,12 @@ load_nba_standings <- function(seasons = most_recent_nba_season(), ...,
 
   out <- lapply(urls, progressively(loader, p))
   out <- rbindlist_with_attrs(out)
-  class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  if (in_db) {
+    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
+    out <- NULL
+  } else {
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  }
   out
 }
 
@@ -710,7 +718,6 @@ load_nba_game_rosters <- function(seasons = most_recent_nba_season(), ...,
                                   dbConnection = NULL, tablename = NULL) {
   old <- options(list(stringsAsFactors = FALSE, scipen = 999))
   on.exit(options(old))
-  dots <- rlang::dots_list(...)
 
   loader <- rds_from_url
   if (!is.null(dbConnection) && !is.null(tablename)) in_db <- TRUE else in_db <- FALSE
@@ -730,7 +737,12 @@ load_nba_game_rosters <- function(seasons = most_recent_nba_season(), ...,
 
   out <- lapply(urls, progressively(loader, p))
   out <- rbindlist_with_attrs(out)
-  class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  if (in_db) {
+    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
+    out <- NULL
+  } else {
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  }
   out
 }
 
@@ -755,7 +767,6 @@ load_nba_officials <- function(seasons = most_recent_nba_season(), ...,
                                dbConnection = NULL, tablename = NULL) {
   old <- options(list(stringsAsFactors = FALSE, scipen = 999))
   on.exit(options(old))
-  dots <- rlang::dots_list(...)
 
   loader <- rds_from_url
   if (!is.null(dbConnection) && !is.null(tablename)) in_db <- TRUE else in_db <- FALSE
@@ -775,7 +786,12 @@ load_nba_officials <- function(seasons = most_recent_nba_season(), ...,
 
   out <- lapply(urls, progressively(loader, p))
   out <- rbindlist_with_attrs(out)
-  class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  if (in_db) {
+    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
+    out <- NULL
+  } else {
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  }
   out
 }
 
@@ -799,7 +815,6 @@ load_nba_draft <- function(seasons = most_recent_nba_season(), ...,
                            dbConnection = NULL, tablename = NULL) {
   old <- options(list(stringsAsFactors = FALSE, scipen = 999))
   on.exit(options(old))
-  dots <- rlang::dots_list(...)
 
   loader <- rds_from_url
   if (!is.null(dbConnection) && !is.null(tablename)) in_db <- TRUE else in_db <- FALSE
@@ -819,7 +834,12 @@ load_nba_draft <- function(seasons = most_recent_nba_season(), ...,
 
   out <- lapply(urls, progressively(loader, p))
   out <- rbindlist_with_attrs(out)
-  class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  if (in_db) {
+    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
+    out <- NULL
+  } else {
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  }
   out
 }
 
@@ -843,7 +863,6 @@ load_nba_player_stats <- function(seasons = most_recent_nba_season(), ...,
                                   dbConnection = NULL, tablename = NULL) {
   old <- options(list(stringsAsFactors = FALSE, scipen = 999))
   on.exit(options(old))
-  dots <- rlang::dots_list(...)
 
   loader <- rds_from_url
   if (!is.null(dbConnection) && !is.null(tablename)) in_db <- TRUE else in_db <- FALSE
@@ -863,7 +882,12 @@ load_nba_player_stats <- function(seasons = most_recent_nba_season(), ...,
 
   out <- lapply(urls, progressively(loader, p))
   out <- rbindlist_with_attrs(out)
-  class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  if (in_db) {
+    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
+    out <- NULL
+  } else {
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  }
   out
 }
 
@@ -887,7 +911,6 @@ load_nba_team_stats <- function(seasons = most_recent_nba_season(), ...,
                                 dbConnection = NULL, tablename = NULL) {
   old <- options(list(stringsAsFactors = FALSE, scipen = 999))
   on.exit(options(old))
-  dots <- rlang::dots_list(...)
 
   loader <- rds_from_url
   if (!is.null(dbConnection) && !is.null(tablename)) in_db <- TRUE else in_db <- FALSE
@@ -907,7 +930,12 @@ load_nba_team_stats <- function(seasons = most_recent_nba_season(), ...,
 
   out <- lapply(urls, progressively(loader, p))
   out <- rbindlist_with_attrs(out)
-  class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  if (in_db) {
+    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
+    out <- NULL
+  } else {
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  }
   out
 }
 
@@ -932,7 +960,6 @@ load_nba_rosters <- function(seasons = most_recent_nba_season(), ...,
                              dbConnection = NULL, tablename = NULL) {
   old <- options(list(stringsAsFactors = FALSE, scipen = 999))
   on.exit(options(old))
-  dots <- rlang::dots_list(...)
 
   loader <- rds_from_url
   if (!is.null(dbConnection) && !is.null(tablename)) in_db <- TRUE else in_db <- FALSE
@@ -952,7 +979,12 @@ load_nba_rosters <- function(seasons = most_recent_nba_season(), ...,
 
   out <- lapply(urls, progressively(loader, p))
   out <- rbindlist_with_attrs(out)
-  class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  if (in_db) {
+    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
+    out <- NULL
+  } else {
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  }
   out
 }
 
@@ -991,7 +1023,6 @@ load_nba_player_core <- function(seasons = most_recent_nba_season(), ...,
                                  dbConnection = NULL, tablename = NULL) {
   old <- options(list(stringsAsFactors = FALSE, scipen = 999))
   on.exit(options(old))
-  dots <- rlang::dots_list(...)
 
   loader <- rds_from_url
   if (!is.null(dbConnection) && !is.null(tablename)) in_db <- TRUE else in_db <- FALSE
@@ -1011,6 +1042,11 @@ load_nba_player_core <- function(seasons = most_recent_nba_season(), ...,
 
   out <- lapply(urls, progressively(loader, p))
   out <- rbindlist_with_attrs(out)
-  class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  if (in_db) {
+    DBI::dbWriteTable(dbConnection, tablename, out, append = TRUE, ...)
+    out <- NULL
+  } else {
+    class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  }
   out
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -634,7 +634,7 @@ NULL
 make_hoopR_data <- function(df, type, timestamp) {
   out <- df
 
-  class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
+  class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
   attr(out, "hoopR_timestamp") <- timestamp
   attr(out, "hoopR_type") <- type
   return(out)
@@ -664,6 +664,6 @@ rbindlist_with_attrs <- function(dflist) {
   out <- data.table::rbindlist(dflist, use.names = TRUE, fill = TRUE)
   attr(out, "hoopR_timestamp") <- hoopR_timestamp
   attr(out, "hoopR_type") <- hoopR_type
-  # class(out) <- c("hoopR_data","tbl_df","tbl","data.table","data.frame")
+  # class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.table", "data.frame")
   out
 }

--- a/tests/testthat/test-hoopR_data_class.R
+++ b/tests/testthat/test-hoopR_data_class.R
@@ -1,0 +1,48 @@
+# Regression test for #88: load_nba_schedule() (and every other in-memory
+# loader / make_hoopR_data() caller) tagged its return value with a class
+# vector that included "data.table" alongside "tbl_df". tail()/head() would
+# dispatch data.table:::tail.data.table(), whose internal `x[i]` row-filter
+# then re-dispatched to tibble:::`[.tbl_df`() (because tbl_df precedes
+# data.table in the class vector) -- which treats a single-bracket index as a
+# COLUMN selector, not a row filter. Result: "Can't subset columns past the
+# end." Fix: drop "data.table" from the public class vector everywhere it is
+# set (see #88 comment thread).
+
+test_that("make_hoopR_data() output supports tail()/head()/print()/dplyr without error", {
+  df <- data.frame(a = 1:10, b = 11:20, c = letters[1:10], stringsAsFactors = FALSE)
+  out <- make_hoopR_data(df, "unit test data", Sys.time())
+
+  expect_false("data.table" %in% class(out))
+  expect_true(all(c("hoopR_data", "tbl_df", "tbl", "data.frame") %in% class(out)))
+
+  tail_out <- tail(out)
+  expect_equal(nrow(tail_out), 6L)
+  expect_equal(tail_out$a, 5:10)
+
+  head_out <- head(out)
+  expect_equal(nrow(head_out), 6L)
+  expect_equal(head_out$a, 1:6)
+
+  expect_error(print(out), NA)
+
+  if (requireNamespace("dplyr", quietly = TRUE)) {
+    filtered <- dplyr::filter(out, a > 5)
+    expect_equal(nrow(filtered), 5L)
+    expect_equal(filtered$a, 6:10)
+  }
+})
+
+test_that("hoopR_data class vector set directly (rbindlist_with_attrs path) supports tail()", {
+  chunks <- list(
+    data.frame(a = 1:5, b = 6:10),
+    data.frame(a = 11:15, b = 16:20)
+  )
+  out <- rbindlist_with_attrs(chunks)
+  class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
+
+  expect_false("data.table" %in% class(out))
+
+  tail_out <- tail(out)
+  expect_equal(nrow(tail_out), 6L)
+  expect_equal(tail_out$a, c(5, 11, 12, 13, 14, 15))
+})

--- a/tests/testthat/test-hoopR_data_class.R
+++ b/tests/testthat/test-hoopR_data_class.R
@@ -32,15 +32,15 @@ test_that("make_hoopR_data() output supports tail()/head()/print()/dplyr without
   }
 })
 
-test_that("hoopR_data class vector set directly (rbindlist_with_attrs path) supports tail()", {
+test_that("production crosswalk bind path emits a tail()-safe class vector", {
   chunks <- list(
     data.frame(a = 1:5, b = 6:10),
     data.frame(a = 11:15, b = 16:20)
   )
-  out <- rbindlist_with_attrs(chunks)
-  class(out) <- c("hoopR_data", "tbl_df", "tbl", "data.frame")
+  out <- .bind_crosswalk_chunks(chunks)
 
   expect_false("data.table" %in% class(out))
+  expect_s3_class(out, "hoopR_data")
 
   tail_out <- tail(out)
   expect_equal(nrow(tail_out), 6L)

--- a/tests/testthat/test-load_db_write_no_op.R
+++ b/tests/testthat/test-load_db_write_no_op.R
@@ -1,0 +1,40 @@
+# Regression tests for #80-style loaders (mirrors wehoop #80): load_nba_team_box()
+# and load_mbb_rosters() (among 16 total) documented a dbConnection/tablename
+# write via DBI::dbWriteTable() but never issued the call -- passing a db
+# connection silently did nothing and still returned the in-memory data. These
+# confirm the write now happens against an in-memory RSQLite database.
+
+test_that("load_nba_team_box writes into the db when dbConnection/tablename are supplied", {
+  skip_on_cran()
+  skip_espn_test()
+  skip_if_not_installed("RSQLite")
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+
+  out <- load_nba_team_box(seasons = most_recent_nba_season(),
+                            dbConnection = con, tablename = "nba_team_box")
+
+  expect_null(out)
+  expect_true(DBI::dbExistsTable(con, "nba_team_box"))
+  tbl <- DBI::dbReadTable(con, "nba_team_box")
+  expect_gt(nrow(tbl), 0)
+  expect_true(all(c("game_id", "team_id", "season") %in% colnames(tbl)))
+})
+
+test_that("load_mbb_rosters writes into the db when dbConnection/tablename are supplied", {
+  skip_on_cran()
+  skip_espn_test()
+  skip_if_not_installed("RSQLite")
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+
+  out <- load_mbb_rosters(seasons = most_recent_mbb_season(),
+                           dbConnection = con, tablename = "mbb_rosters")
+
+  expect_null(out)
+  expect_true(DBI::dbExistsTable(con, "mbb_rosters"))
+  tbl <- DBI::dbReadTable(con, "mbb_rosters")
+  expect_gt(nrow(tbl), 0)
+})

--- a/tests/testthat/test-load_db_write_no_op.R
+++ b/tests/testthat/test-load_db_write_no_op.R
@@ -6,6 +6,7 @@
 
 test_that("load_nba_team_box writes into the db when dbConnection/tablename are supplied", {
   skip_on_cran()
+  skip_on_ci()
   skip_espn_test()
   skip_if_not_installed("RSQLite")
 
@@ -24,6 +25,7 @@ test_that("load_nba_team_box writes into the db when dbConnection/tablename are 
 
 test_that("load_mbb_rosters writes into the db when dbConnection/tablename are supplied", {
   skip_on_cran()
+  skip_on_ci()
   skip_espn_test()
   skip_if_not_installed("RSQLite")
 

--- a/tests/testthat/test-load_dots_forwarding.R
+++ b/tests/testthat/test-load_dots_forwarding.R
@@ -5,6 +5,7 @@
 
 test_that("load_nba_pbp forwards ... to DBI::dbWriteTable", {
   skip_on_cran()
+  skip_on_ci()
   skip_espn_test()
   skip_if_not_installed("RSQLite")
 
@@ -23,6 +24,7 @@ test_that("load_nba_pbp forwards ... to DBI::dbWriteTable", {
 
 test_that("load_mbb_pbp forwards ... to DBI::dbWriteTable", {
   skip_on_cran()
+  skip_on_ci()
   skip_espn_test()
   skip_if_not_installed("RSQLite")
 

--- a/tests/testthat/test-load_dots_forwarding.R
+++ b/tests/testthat/test-load_dots_forwarding.R
@@ -1,0 +1,38 @@
+# Regression test: every load_* db-writing loader ran `dots <- rlang::dots_list(...)`
+# but never forwarded `...` into DBI::dbWriteTable(), despite roxygen promising
+# forwarded dots for the underlying write (`append = TRUE` was hardcoded with no
+# way to pass e.g. row.names, overwrite, or a custom DBI field.types map).
+
+test_that("load_nba_pbp forwards ... to DBI::dbWriteTable", {
+  skip_on_cran()
+  skip_espn_test()
+  skip_if_not_installed("RSQLite")
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+
+  out <- load_nba_pbp(seasons = most_recent_nba_season(),
+                       dbConnection = con, tablename = "nba_pbp",
+                       row.names = TRUE)
+
+  expect_null(out)
+  # row.names = TRUE only reaches DBI::dbWriteTable() if `...` is forwarded;
+  # a dropped `...` would write the table without a row_names column.
+  expect_true("row_names" %in% DBI::dbListFields(con, "nba_pbp"))
+})
+
+test_that("load_mbb_pbp forwards ... to DBI::dbWriteTable", {
+  skip_on_cran()
+  skip_espn_test()
+  skip_if_not_installed("RSQLite")
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+
+  out <- load_mbb_pbp(seasons = most_recent_mbb_season(),
+                       dbConnection = con, tablename = "mbb_pbp",
+                       row.names = TRUE)
+
+  expect_null(out)
+  expect_true("row_names" %in% DBI::dbListFields(con, "mbb_pbp"))
+})


### PR DESCRIPTION
## Summary

- Forward `...` into `DBI::dbWriteTable()` across the 7 loaders that already write, and drop the dead `dots <- rlang::dots_list(...)` capture that never fed anywhere (mirrors wehoop #78).
- Perform the documented `DBI::dbWriteTable()` write in 16 loaders that accepted/documented `dbConnection`/`tablename` but silently never wrote (`load_nba_{team_box,standings,game_rosters,officials,draft,player_stats,team_stats,rosters,player_core}`, `load_mbb_{rosters,player_stats,team_stats,standings,game_rosters,officials,player_core}`) (mirrors wehoop #80).
- Repair the `hoopR_data` class vector (`make_hoopR_data()`, all `load_nba_*`/`load_mbb_*` loaders, the crosswalk loader) by dropping `"data.table"` -- it was mixed into the class vector alongside `"tbl_df"` without the internal state `data.table` needs, so `tail()`/`head()` dispatched `data.table:::tail.data.table()`, whose row-filter `x[i]` then re-dispatched to `tibble:::[.tbl_df()` (column semantics, not row semantics), reproducing `tail(load_nba_schedule(2019:2022))` -> `Error in x[i]: Can't subset columns past the end.` exactly as reported.

Fixes #88

## Test plan

- [x] New offline regression suite `tests/testthat/test-hoopR_data_class.R` (mutation-tested: reverting the class-vector fix makes it fail) covering `tail()`/`head()`/`print()`/`dplyr::filter()` on both the `make_hoopR_data()` path and the direct `rbindlist_with_attrs()` + `class<-` path.
- [x] New RSQLite in-memory tests (`test-load_dots_forwarding.R`, `test-load_db_write_no_op.R`) proving the write happens, expected columns are present, and `...` forwarding reaches `DBI::dbWriteTable()` (via `row.names = TRUE` producing a `row_names` column).
- [x] Live-verified against the exact #88 repros with real data: `tail(load_nba_schedule(2019:2022))` (5010 rows), `load_nba_team_box(2022)`, and `load_nba_player_box(2022)` all now succeed.
- [x] `devtools::document()` run (no roxygen changes needed; a pre-existing unrelated `@keywords` NOTE in `nba_tracking.R` is untouched by this branch).
- [x] All R files touched parse cleanly.

## Summary by Sourcery

Repair loader database persistence and argument forwarding while making hoopR_data results safe for standard data-frame operations.

Bug Fixes:
- Restore database writes for loaders that accepted database connection and table arguments but did not persist their results.
- Forward loader arguments to DBI table writes so database-specific write options are honored.
- Fix hoopR_data class vectors to prevent head(), tail(), and related operations from dispatching through data.table incorrectly.

Enhancements:
- Remove unused variadic-argument capture and centralize crosswalk result binding while preserving the public data class.

Tests:
- Add regression coverage for hoopR_data operations and database persistence and argument forwarding using offline and in-memory SQLite tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized in-memory loader results as `hoopR_data` tibbles without the `data.table` class.
  * Improved database-loading behavior by correctly forwarding table-writing options.
  * Ensured database-backed loads write expected tables and return no unnecessary in-memory result.

* **Tests**
  * Added regression coverage for data handling, database writes, option forwarding, and common table operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->