### PR TITLE
fix(espn,kp): betting cascade, conference-grouped teams/standings, season scoreboard, depth chart

### DIFF
--- a/R/espn_basketball_event_betting_helpers.R
+++ b/R/espn_basketball_event_betting_helpers.R
@@ -11,8 +11,7 @@
 #'
 #' Fetches
 #' `sports.core.api.espn.com/v2/sports/basketball/leagues/{league}/events/{event_id}/competitions/{event_id}/odds`
-#' and returns a tidy tibble (one row per provider). MBB will typically return
-#' an empty tibble because ESPN does not carry NCAA basketball odds lines.
+#' and returns a tidy tibble (one row per provider).
 #'
 #' @param league character. `"nba"` or `"mens-college-basketball"`.
 #' @param event_id character or numeric. ESPN event/game identifier.
@@ -143,6 +142,78 @@
     finally = {}
   )
   return(result)
+}
+
+# ---------------------------------------------------------------------------
+# .espn_basketball_pickcenter_fallback
+# ---------------------------------------------------------------------------
+
+#' Internal: build a pickcenter-shaped tibble from Core v2 event odds
+#'
+#' ESPN's Site v2 `summary` payload now frequently ships an empty
+#' `pickcenter` array (key present, zero rows) -- see hoopR issues #136,
+#' #153, #173. The Core v2 `.../odds` endpoint still carries the same
+#' provider-level betting lines, so this maps its columns onto the
+#' documented `pickcenter` shape (columns the Core v2 odds payload
+#' doesn't carry, e.g. spread odds / win percentage, are filled `NA`).
+#'
+#' @param league character. `"nba"` or `"mens-college-basketball"`.
+#' @param game_id character or numeric. ESPN event/game identifier.
+#' @return A `hoopR_data` tibble with the `pickcenter` column shape,
+#'   or a zero-row/column `data.frame()` if the Core v2 odds endpoint
+#'   has no providers either.
+#' @noRd
+.espn_basketball_pickcenter_fallback <- function(league, game_id) {
+  odds <- tryCatch(
+    .espn_basketball_event_odds(league = league, event_id = game_id),
+    error = function(e) NULL
+  )
+  if (is.null(odds) || nrow(odds) == 0) {
+    return(data.frame())
+  }
+  odds %>%
+    dplyr::transmute(
+      details = .data$details,
+      over_under = .data$over_under,
+      spread = .data$spread,
+      provider_id = suppressWarnings(as.integer(.data$provider_id)),
+      provider_name = .data$provider_name,
+      provider_priority = NA_integer_,
+      away_team_odds_favorite = NA,
+      away_team_odds_underdog = NA,
+      away_team_odds_money_line = .data$away_money_line,
+      away_team_odds_spread_odds = NA_real_,
+      away_team_odds_team_id = NA_integer_,
+      away_team_odds_win_percentage = NA_real_,
+      away_team_odds_average_score = NA_real_,
+      away_team_odds_money_line_odds = NA_real_,
+      away_team_odds_spread_return = NA_real_,
+      away_team_odds_spread_record_wins = NA_integer_,
+      away_team_odds_spread_record_losses = NA_integer_,
+      away_team_odds_spread_record_pushes = NA_integer_,
+      away_team_odds_spread_record_summary = NA_character_,
+      home_team_odds_favorite = NA,
+      home_team_odds_underdog = NA,
+      home_team_odds_money_line = .data$home_money_line,
+      home_team_odds_spread_odds = NA_real_,
+      home_team_odds_team_id = NA_integer_,
+      home_team_odds_win_percentage = NA_real_,
+      home_team_odds_average_score = NA_real_,
+      home_team_odds_money_line_odds = NA_real_,
+      home_team_odds_spread_return = NA_real_,
+      home_team_odds_spread_record_wins = NA_integer_,
+      home_team_odds_spread_record_losses = NA_integer_,
+      home_team_odds_spread_record_pushes = NA_integer_,
+      home_team_odds_spread_record_summary = NA_character_,
+      game_id = as.integer(game_id)
+    ) %>%
+    make_hoopR_data(
+      paste0(
+        "ESPN ", toupper(league),
+        " Pickcenter Information (Core v2 odds fallback) from ESPN.com"
+      ),
+      Sys.time()
+    )
 }
 
 # ---------------------------------------------------------------------------

--- a/R/espn_mbb_data.R
+++ b/R/espn_mbb_data.R
@@ -2320,6 +2320,9 @@ espn_mbb_betting <- function(game_id) {
 
     }
   )
+  if (nrow(pickcenter) == 0) {
+    pickcenter <- .espn_basketball_pickcenter_fallback("mens-college-basketball", game_id)
+  }
   betting <-
     c(
       list(pickcenter),

--- a/R/espn_mbb_data.R
+++ b/R/espn_mbb_data.R
@@ -1760,7 +1760,7 @@ parse_espn_mbb_scoreboard <- function(group, season_dates) {
 #' try(espn_mbb_scoreboard(season = "20221117"))
 #' }
 espn_mbb_scoreboard <- function(season) {
-  max_year <- substr(Sys.Date(), 1, 4)
+  max_year <- as.integer(substr(Sys.Date(), 1, 4))
 
   if (!(as.integer(substr(season, 1, 4)) > 2001)) {
     message(paste("Error: Season must be between 2001 and", max_year + 1))
@@ -1769,21 +1769,67 @@ espn_mbb_scoreboard <- function(season) {
   # year > 2000
   season <- as.character(season)
 
-  season_dates <- season
+  # A bare 4-digit season (e.g. "2024") is a season YEAR, not a calendar
+  # year -- the MBB season runs November of {season - 1} through April of
+  # {season}. ESPN's `dates=` param treats a bare year as calendar-year-only
+  # (Jan 1 onward), silently dropping the season's November/December games
+  # (#150). Query both the season year and the prior calendar year and
+  # filter down to the games ESPN itself assigns to this season; ESPN
+  # rejects date-RANGE syntax for MBB, so this has to be two separate
+  # `dates=` requests per group rather than one `dates=Y0101-Y1231` call.
+  # A specific date (e.g. "20231108", the documented single-day usage) is
+  # left untouched -- it already resolves to the right games.
+  is_season_year <- nchar(season) == 4L
+  season_dates <- if (is_season_year) {
+    c(as.character(as.integer(season) - 1L), season)
+  } else {
+    season
+  }
 
   # check for regular and postseason games
 
   scoreboard_df <-
     purrr::map2_dfr(
-      c("56", "55", "50", "100"),
-      rep(season, 4),
+      rep(c("56", "55", "50", "100"), each = length(season_dates)),
+      rep(season_dates, times = 4),
       parse_espn_mbb_scoreboard
     )
 
+  if (is_season_year) {
+    # The regular-season group ("50") runs thousands of games/year, so a
+    # single `dates={season - 1}` whole-year request above hits ESPN's
+    # `limit=1000` cap in mid-January and never reaches November/December
+    # -- the exact months this fix needs. Backfill them with one request
+    # per day (postseason groups 56/55/100 never play in Nov/Dec, so only
+    # "50" needs this).
+    fall_dates <- format(
+      seq(
+        as.Date(paste0(as.integer(season) - 1L, "-11-01")),
+        as.Date(paste0(as.integer(season) - 1L, "-12-31")),
+        by = "day"
+      ),
+      "%Y%m%d"
+    )
+    fall_df <- purrr::map_dfr(
+      fall_dates,
+      function(d) parse_espn_mbb_scoreboard(group = "50", season_dates = d)
+    )
+    scoreboard_df <- dplyr::bind_rows(scoreboard_df, fall_df)
+  }
+
+  if (is_season_year && nrow(scoreboard_df)) {
+    # `.env$season` disambiguates the function argument from the identically
+    # named `season` data column -- dplyr's data mask otherwise resolves the
+    # bare name to the column on both sides, making this filter a silent
+    # no-op.
+    scoreboard_df <- scoreboard_df %>%
+      dplyr::filter(as.integer(.data$season) == as.integer(.env$season))
+  }
+
   # A game can be returned under more than one ESPN group ID (e.g. a
   # Division I conference tournament game also carries a national group
-  # tag), so the four-group union above can duplicate rows for the same
-  # game_id. Keep one row per game (#160).
+  # tag), and the per-day fall backfill re-returns games the whole-year
+  # request already captured, so keep one row per game (#160).
   if (nrow(scoreboard_df) && "game_id" %in% names(scoreboard_df)) {
     scoreboard_df <- scoreboard_df %>%
       dplyr::distinct(.data$game_id, .keep_all = TRUE)

--- a/R/espn_mbb_data.R
+++ b/R/espn_mbb_data.R
@@ -1257,6 +1257,51 @@ espn_mbb_teams <- function(year = most_recent_mbb_season()) {
         return(conf_items)
       })
 
+      # ESPN's flat teams?limit=1000 list silently drops some current D1
+      # teams (#144, e.g. Queens/Lindenwood/Southern Indiana) that the
+      # conference-group listing above still carries. Backfill any team_id
+      # present in conference_teams but missing from the flat fetch by
+      # querying it individually before joining conference info back on.
+      missing_team_ids <- setdiff(unique(conference_teams$team_id), teams$team_id)
+      if (length(missing_team_ids) > 0) {
+        missing_teams <- purrr::map_dfr(missing_team_ids, function(tid) {
+          t_res <- tryCatch(
+            .retry_request(paste0(
+              "http://site.api.espn.com/apis/site/v2/sports/basketball/mens-college-basketball/teams/",
+              tid
+            )),
+            error = function(e) NULL
+          )
+          if (is.null(t_res) || httr2::resp_status(t_res) != 200L) {
+            return(NULL)
+          }
+          # Named `team_json` (not `team`) -- tibble() argument evaluation is
+          # data-masked, so a `team = ` output column would otherwise shadow
+          # this list for every later argument in the same tibble() call.
+          team_json <- t_res %>% .resp_text() %>% jsonlite::fromJSON() %>% purrr::pluck("team")
+          if (is.null(team_json) || is.null(team_json[["id"]])) {
+            return(NULL)
+          }
+          logos <- team_json[["logos"]]
+          tibble::tibble(
+            team_id = as.integer(team_json[["id"]]),
+            abbreviation = team_json[["abbreviation"]] %||% NA_character_,
+            display_name = team_json[["displayName"]] %||% NA_character_,
+            short_name = team_json[["shortDisplayName"]] %||% NA_character_,
+            mascot = team_json[["name"]] %||% NA_character_,
+            nickname = team_json[["nickname"]] %||% NA_character_,
+            team = team_json[["location"]] %||% NA_character_,
+            color = team_json[["color"]] %||% NA_character_,
+            alternate_color = team_json[["alternateColor"]] %||% NA_character_,
+            logo = if (is.data.frame(logos) && nrow(logos) > 0) logos[["href"]][1] else NA_character_,
+            logo_dark = if (is.data.frame(logos) && nrow(logos) > 1) logos[["href"]][2] else NA_character_
+          )
+        })
+        if (!is.null(missing_teams) && nrow(missing_teams) > 0) {
+          teams <- dplyr::bind_rows(teams, missing_teams)
+        }
+      }
+
       teams <- teams %>%
         dplyr::left_join(conference_teams, by = c("team_id" = "team_id")) %>%
         dplyr::left_join(conferences, by = c("group_id" = "group_id")) %>%
@@ -1897,6 +1942,7 @@ espn_mbb_rankings <- function() {
 #'    |:---------------------------------|:---------|:-----------------------------------------------------|
 #'    |team_id                           |integer   |Unique team identifier.                               |
 #'    |team                              |character |Team-side label or team identifier.                   |
+#'    |conference                        |character |Conference group name from ESPN standings.            |
 #'    |avgpointsagainst                  |numeric   |Avgpointsagainst.                                     |
 #'    |avgpointsfor                      |numeric   |Avgpointsfor.                                         |
 #'    |gamesbehind                       |numeric   |Gamesbehind.                                          |
@@ -1984,7 +2030,7 @@ espn_mbb_rankings <- function() {
 espn_mbb_standings <- function(year = most_recent_mbb_season()) {
   .args <- mget(setdiff(names(formals()), "..."))
   standings_url <-
-    "https://site.web.api.espn.com/apis/v2/sports/basketball/mens-college-basketball/standings?region=us&lang=en&contentorigin=espn&type=0&level=1&sort=winpercent%3Adesc%2Cwins%3Adesc%2Cgamesbehind%3Aasc&"
+    "https://site.web.api.espn.com/apis/v2/sports/basketball/mens-college-basketball/standings?region=us&lang=en&contentorigin=espn&type=0&level=3&sort=winpercent%3Adesc%2Cwins%3Adesc%2Cgamesbehind%3Aasc&"
 
   ## Inputs
   ## year
@@ -2008,16 +2054,39 @@ espn_mbb_standings <- function(year = most_recent_mbb_season()) {
       raw_resp <- resp %>%
         jsonlite::fromJSON()
 
-      raw_standings <- raw_resp %>%
-        purrr::pluck("standings")
-      # Create a dataframe of all NBA teams by extracting from the raw_standings file
+      # level=3 groups standings by conference under "children"; ESPN's flat
+      # level=1 list silently omits some current D1 teams (#144), so
+      # row-bind each conference group's entries instead.
+      raw_children <- raw_resp %>%
+        purrr::pluck("children")
+
+      conference_entries <- raw_children[["standings"]][["entries"]]
+      conference_names <- raw_children[["name"]]
+
+      # Conferences with no season played yet come back with a NULL entries
+      # list -- drop them instead of binding a bogus row.
+      has_entries <- !vapply(conference_entries, is.null, logical(1))
+
+      entries_list <- Map(
+        function(entries, conference) {
+          entries$conference <- conference
+          entries
+        },
+        conference_entries[has_entries],
+        conference_names[has_entries]
+      )
+
+      raw_standings <- list(entries = dplyr::bind_rows(entries_list))
+      # Create a dataframe of all MBB teams by extracting from the raw_standings file
 
       teams <- raw_standings[["entries"]][["team"]]
+      teams$conference <- raw_standings[["entries"]][["conference"]]
 
       teams <- teams %>%
         dplyr::select(
           "id",
-          "displayName"
+          "displayName",
+          "conference"
         ) %>%
         dplyr::rename(
           "team_id" = "id",

--- a/R/espn_nba_data.R
+++ b/R/espn_nba_data.R
@@ -1376,7 +1376,7 @@ espn_nba_team_current_roster <- function(team_id) {
 #' }
 espn_nba_scoreboard <- function(season) {
   .args <- mget(setdiff(names(formals()), "..."))
-  max_year <- substr(Sys.Date(), 1, 4)
+  max_year <- as.integer(substr(Sys.Date(), 1, 4))
 
   if (!(as.integer(substr(season, 1, 4)) > 2001)) {
     message(paste("Error: Season must be between 2001 and", max_year + 1))

--- a/R/espn_nba_data.R
+++ b/R/espn_nba_data.R
@@ -2105,6 +2105,9 @@ espn_nba_betting <- function(game_id) {
     warning = function(w) {},
     finally = {}
   )
+  if (nrow(pickcenter) == 0) {
+    pickcenter <- .espn_basketball_pickcenter_fallback("nba", game_id)
+  }
   betting <- c(list(pickcenter), list(againstTheSpread), list(predictor_df))
   names(betting) <- c("pickcenter", "againstTheSpread", "predictor")
   return(betting)

--- a/R/kp_team_tables.R
+++ b/R/kp_team_tables.R
@@ -1998,52 +1998,30 @@ kp_team_player_stats <- function(team, year = 2021){
 #'
 #' @param team Team filter to select.
 #' @param year Year of data to pull
-#' @return A data frame with the following columns:
+#' @return A data frame with one row per rostered player, with the following columns:
 #'
-#'    |col_name             |types     |description                                  |
-#'    |:--------------------|:---------|:--------------------------------------------|
-#'    |pg_number            |numeric   |Pg number.                                   |
-#'    |pg_player_first_name |character |Pg player first name.                        |
-#'    |pg_player_last_name  |character |Pg player last name.                         |
-#'    |pg_hgt               |character |Pg hgt.                                      |
-#'    |pg_wgt               |numeric   |Pg wgt.                                      |
-#'    |pg_yr                |character |Pg yr.                                       |
-#'    |pg_min_pct           |numeric   |Pg min percentage (0-1 decimal).             |
-#'    |sg_number            |numeric   |Sg number.                                   |
-#'    |sg_player_first_name |character |Sg player first name.                        |
-#'    |sg_player_last_name  |character |Sg player last name.                         |
-#'    |sg_hgt               |character |Sg hgt.                                      |
-#'    |sg_wgt               |numeric   |Sg wgt.                                      |
-#'    |sg_yr                |character |Sg yr.                                       |
-#'    |sg_min_pct           |numeric   |Sg min percentage (0-1 decimal).             |
-#'    |sf_number            |numeric   |Sf number.                                   |
-#'    |sf_player_first_name |character |Sf player first name.                        |
-#'    |sf_player_last_name  |character |Sf player last name.                         |
-#'    |sf_hgt               |character |Sf hgt.                                      |
-#'    |sf_wgt               |numeric   |Sf wgt.                                      |
-#'    |sf_yr                |character |Sf yr.                                       |
-#'    |sf_min_pct           |numeric   |Sf min percentage (0-1 decimal).             |
-#'    |pf_number            |numeric   |Pf number.                                   |
-#'    |pf_player_first_name |character |Personal fouls player first name.            |
-#'    |pf_player_last_name  |character |Personal fouls player last name.             |
-#'    |pf_hgt               |character |Pf hgt.                                      |
-#'    |pf_wgt               |numeric   |Pf wgt.                                      |
-#'    |pf_yr                |character |Pf yr.                                       |
-#'    |pf_min_pct           |numeric   |Personal fouls min percentage (0-1 decimal). |
-#'    |c_number             |numeric   |C number.                                    |
-#'    |c_player_first_name  |character |C player first name.                         |
-#'    |c_player_last_name   |character |C player last name.                          |
-#'    |c_hgt                |character |C hgt.                                       |
-#'    |c_wgt                |numeric   |C wgt.                                       |
-#'    |c_yr                 |character |C yr.                                        |
-#'    |c_min_pct            |numeric   |C min percentage (0-1 decimal).              |
-#'    |team                 |character |Team-side label or team identifier.          |
-#'    |year                 |numeric   |4-digit year.                                |
+#'    |col_name    |types     |description                                                  |
+#'    |:-----------|:---------|:-------------------------------------------------------------|
+#'    |team        |character |Team-side label or team identifier.                            |
+#'    |year        |numeric   |4-digit year.                                                  |
+#'    |player_id   |integer   |KenPom player identifier.                                       |
+#'    |player_name |character |Player full name.                                               |
+#'    |class_year  |character |Class year (e.g. 'Fr', 'So', 'Jr', 'Sr').                       |
+#'    |height      |character |Height (e.g. '6-9').                                            |
+#'    |weight      |numeric   |Weight in pounds.                                               |
+#'    |pct_pg      |numeric   |Percentage of the player's minutes played at point guard (0-1 decimal). |
+#'    |pct_sg      |numeric   |Percentage of the player's minutes played at shooting guard (0-1 decimal). |
+#'    |pct_sf      |numeric   |Percentage of the player's minutes played at small forward (0-1 decimal). |
+#'    |pct_pf      |numeric   |Percentage of the player's minutes played at power forward (0-1 decimal). |
+#'    |pct_c       |numeric   |Percentage of the player's minutes played at center (0-1 decimal). |
+#'    |pct_poss    |numeric   |Percentage of team possessions used while the player was on the floor (0-1 decimal). |
+#'    |fta         |integer   |Season free throw attempts.                                     |
+#'    |fg2a        |integer   |Season 2-point field goal attempts.                             |
+#'    |fg3a        |integer   |Season 3-point field goal attempts.                             |
 #'
 #' @importFrom cli cli_abort
-#' @importFrom dplyr select mutate filter  bind_cols bind_rows
-#' @importFrom stringr str_extract str_remove str_replace str_detect str_trim
-#' @importFrom tidyr separate
+#' @importFrom dplyr select mutate filter rename
+#' @importFrom stringr str_extract
 #' @import rvest
 #' @export
 #' @keywords Depth Chart
@@ -2085,125 +2063,60 @@ kp_team_depth_chart <- function(team, year= 2021){
 
       page <- .kp_get_page(browser, url)
       Sys.sleep(5)
-      depth1_header_cols <- c("PG", "PG.Min.Pct", "SG", "SG.Min.Pct", "SF", "SF.Min.Pct",
-                             "PF", "PF.Min.Pct", "C", "C.Min.Pct")
 
-      depth1 <- (page %>%
-                   rvest::html_elements(css = '#dc-table'))[[1]] %>%
-        rvest::html_table() %>%
-        as.data.frame()
+      # KenPom removed the `#dc-table` depth chart table (#152); team.php
+      # now renders an empty `<div id="depth-chart">` client-side from a
+      # `const players = [...]` JSON array embedded in an inline <script>
+      # tag. Extract that JSON directly rather than scraping rendered HTML.
+      scripts <- page %>% rvest::html_elements("script") %>% rvest::html_text()
+      players_script <- scripts[stringr::str_detect(scripts, "const players = ")]
+      if (length(players_script) == 0) {
+        cli::cli_abort("Could not find the depth chart player data on KenPom's team page -- the site layout may have changed again.")
+      }
+      players_json <- stringr::str_extract(players_script[[1]], "const players = (\\[.*?\\]);", group = 1)
 
-      colnames(depth1) <- depth1_header_cols
-
-      suppressWarnings(
-        depth1 <- depth1 %>%
-          dplyr::filter(.data$PG != "PG")
-      )
-
-      depth1 <- depth1 %>%
+      depth1 <- jsonlite::fromJSON(players_json) %>%
+        dplyr::rename(
+          player_id = "playerID",
+          player_name = "Name",
+          class_year = "Year",
+          height = "Height",
+          weight = "Weight"
+        ) %>%
         dplyr::mutate(
-          PG.Yr = substr(.data$PG, nchar(.data$PG) - 2, nchar(.data$PG)),
-          PG = substr(.data$PG, 1, nchar(.data$PG) - 3),
-          PG.Wgt = stringr::str_extract(.data$PG, '\\d{3}'),
-          PG = stringr::str_trim(stringr::str_remove(.data$PG, '\\d{3}')),
-          PG.Hgt = stringr::str_extract(.data$PG, '\\d{1}-\\d{0,2}'),
-          PG = stringr::str_remove(.data$PG, '\\d{1}-\\d{0,2}'),
-          SG.Yr = substr(.data$SG, nchar(.data$SG) - 2, nchar(.data$SG)),
-          SG = substr(.data$SG, 1, nchar(.data$SG) - 3),
-          SG.Wgt = stringr::str_extract(.data$SG, '\\d{3}'),
-          SG = stringr::str_trim(stringr::str_remove(.data$SG, '\\d{3}')),
-          SG.Hgt = stringr::str_extract(.data$SG, '\\d{1}-\\d{0,2}'),
-          SG = stringr::str_remove(.data$SG, '\\d{1}-\\d{0,2}'),
-          SF.Yr = substr(.data$SF, nchar(.data$SF) - 2, nchar(.data$SF)),
-          SF = substr(.data$SF, 1, nchar(.data$SF) - 3),
-          SF.Wgt = stringr::str_extract(.data$SF, '\\d{3}'),
-          SF = stringr::str_trim(stringr::str_remove(.data$SF, '\\d{3}')),
-          SF.Hgt = stringr::str_extract(.data$SF, '\\d{1}-\\d{0,2}'),
-          SF = stringr::str_remove(.data$SF, '\\d{1}-\\d{0,2}'),
-          PF.Yr = substr(.data$PF, nchar(.data$PF) - 2, nchar(.data$PF)),
-          PF = substr(.data$PF, 1, nchar(.data$PF) - 3),
-          PF.Wgt = stringr::str_extract(.data$PF,'\\d{3}'),
-          PF = stringr::str_trim(stringr::str_remove(.data$PF,'\\d{3}')),
-          PF.Hgt = stringr::str_extract(.data$PF, '\\d{1}-\\d{0,2}'),
-          PF = stringr::str_remove(.data$PF, '\\d{1}-\\d{0,2}'),
-          C.Yr = substr(.data$C, nchar(.data$C) - 2, nchar(.data$C)),
-          C = substr(.data$C, 1, nchar(.data$C) - 3),
-          C.Wgt = stringr::str_extract(.data$C, '\\d{3}'),
-          C = stringr::str_trim(stringr::str_remove(.data$C, '\\d{3}')),
-          C.Hgt = stringr::str_extract(.data$C, '\\d{1}-\\d{0,2}'),
-          C = stringr::str_remove(.data$C, '\\d{1}-\\d{0,2}')
-        )
-      suppressWarnings(
-        depth1 <- depth1 %>%
-          tidyr::separate("PG", into = c("PG.Number", "PG.PlayerFirstName", "PG.PlayerLastName"), sep = "[^\\w']") %>%
-          tidyr::separate("SG", into = c("SG.Number", "SG.PlayerFirstName", "SG.PlayerLastName"), sep = "[^\\w']") %>%
-          tidyr::separate("SF", into = c("SF.Number", "SF.PlayerFirstName", "SF.PlayerLastName"), sep = "[^\\w']") %>%
-          tidyr::separate("PF", into = c("PF.Number", "PF.PlayerFirstName", "PF.PlayerLastName"), sep = "[^\\w']") %>%
-          tidyr::separate("C", into = c("C.Number", "C.PlayerFirstName", "C.PlayerLastName"), sep = "[^\\w']")
-      )
-      suppressWarnings(
-        depth1 <- depth1 %>%
-          dplyr::mutate(
-            Team = team,
-            Year = year,
-            PG.Min.Pct = as.numeric(stringr::str_replace(.data$PG.Min.Pct, '%', ''))/100,
-            SG.Min.Pct = as.numeric(stringr::str_replace(.data$SG.Min.Pct, '%', ''))/100,
-            SF.Min.Pct = as.numeric(stringr::str_replace(.data$SF.Min.Pct, '%', ''))/100,
-            PF.Min.Pct = as.numeric(stringr::str_replace(.data$PF.Min.Pct, '%', ''))/100,
-            C.Min.Pct = as.numeric(stringr::str_replace(.data$C.Min.Pct, '%', ''))/100,
-            PG.Number = as.numeric(.data$PG.Number),
-            SG.Number = as.numeric(.data$SG.Number),
-            SF.Number = as.numeric(.data$SF.Number),
-            PF.Number = as.numeric(.data$PF.Number),
-            C.Number = as.numeric(.data$C.Number),
-            PG.Wgt = as.numeric(.data$PG.Wgt),
-            SG.Wgt = as.numeric(.data$SG.Wgt),
-            SF.Wgt = as.numeric(.data$SF.Wgt),
-            PF.Wgt = as.numeric(.data$PF.Wgt),
-            C.Wgt = as.numeric(.data$C.Wgt))
-      )
-      depth1 <- depth1 %>%
+          team = team,
+          year = year,
+          pct_pg = .data$PctPG / 100,
+          pct_sg = .data$PctSG / 100,
+          pct_sf = .data$PctSF / 100,
+          pct_pf = .data$PctPF / 100,
+          pct_c = .data$PctC / 100,
+          pct_poss = .data$PctPoss / 100,
+          fta = as.integer(.data$FTA),
+          fg2a = as.integer(.data$FG2A),
+          fg3a = as.integer(.data$FG3A)
+        ) %>%
         dplyr::select(
-          "PG.Number",
-          "PG.PlayerFirstName",
-          "PG.PlayerLastName",
-          "PG.Hgt",
-          "PG.Wgt",
-          "PG.Yr",
-          "PG.Min.Pct",
-          "SG.Number",
-          "SG.PlayerFirstName",
-          "SG.PlayerLastName",
-          "SG.Hgt",
-          "SG.Wgt",
-          "SG.Yr",
-          "SG.Min.Pct",
-          "SF.Number",
-          "SF.PlayerFirstName",
-          "SF.PlayerLastName",
-          "SF.Hgt",
-          "SF.Wgt",
-          "SF.Yr",
-          "SF.Min.Pct",
-          "PF.Number",
-          "PF.PlayerFirstName",
-          "PF.PlayerLastName",
-          "PF.Hgt",
-          "PF.Wgt",
-          "PF.Yr",
-          "PF.Min.Pct",
-          "C.Number",
-          "C.PlayerFirstName",
-          "C.PlayerLastName",
-          "C.Hgt",
-          "C.Wgt",
-          "C.Yr",
-          "C.Min.Pct",
-          "Team",
-          "Year")
+          "team",
+          "year",
+          "player_id",
+          "player_name",
+          "class_year",
+          "height",
+          "weight",
+          "pct_pg",
+          "pct_sg",
+          "pct_sf",
+          "pct_pf",
+          "pct_c",
+          "pct_poss",
+          "fta",
+          "fg2a",
+          "fg3a"
+        )
+
       ### Store Data
-      kenpom <- depth1 %>%
-        janitor::clean_names()
+      kenpom <- depth1
     },
     error = function(e) .report_api_error(
       e,

--- a/man/espn_mbb_standings.Rd
+++ b/man/espn_mbb_standings.Rd
@@ -14,6 +14,7 @@ A standings data frame\tabular{lll}{
    col_name \tab types \tab description \cr
    team_id \tab integer \tab Unique team identifier. \cr
    team \tab character \tab Team-side label or team identifier. \cr
+   conference \tab character \tab Conference group name from ESPN standings. \cr
    avgpointsagainst \tab numeric \tab Avgpointsagainst. \cr
    avgpointsfor \tab numeric \tab Avgpointsfor. \cr
    gamesbehind \tab numeric \tab Gamesbehind. \cr

--- a/man/kp_team_depth_chart.Rd
+++ b/man/kp_team_depth_chart.Rd
@@ -12,45 +12,24 @@ kp_team_depth_chart(team, year = 2021)
 \item{year}{Year of data to pull}
 }
 \value{
-A data frame with the following columns:\tabular{lll}{
+A data frame with one row per rostered player, with the following columns:\tabular{lll}{
    col_name \tab types \tab description \cr
-   pg_number \tab numeric \tab Pg number. \cr
-   pg_player_first_name \tab character \tab Pg player first name. \cr
-   pg_player_last_name \tab character \tab Pg player last name. \cr
-   pg_hgt \tab character \tab Pg hgt. \cr
-   pg_wgt \tab numeric \tab Pg wgt. \cr
-   pg_yr \tab character \tab Pg yr. \cr
-   pg_min_pct \tab numeric \tab Pg min percentage (0-1 decimal). \cr
-   sg_number \tab numeric \tab Sg number. \cr
-   sg_player_first_name \tab character \tab Sg player first name. \cr
-   sg_player_last_name \tab character \tab Sg player last name. \cr
-   sg_hgt \tab character \tab Sg hgt. \cr
-   sg_wgt \tab numeric \tab Sg wgt. \cr
-   sg_yr \tab character \tab Sg yr. \cr
-   sg_min_pct \tab numeric \tab Sg min percentage (0-1 decimal). \cr
-   sf_number \tab numeric \tab Sf number. \cr
-   sf_player_first_name \tab character \tab Sf player first name. \cr
-   sf_player_last_name \tab character \tab Sf player last name. \cr
-   sf_hgt \tab character \tab Sf hgt. \cr
-   sf_wgt \tab numeric \tab Sf wgt. \cr
-   sf_yr \tab character \tab Sf yr. \cr
-   sf_min_pct \tab numeric \tab Sf min percentage (0-1 decimal). \cr
-   pf_number \tab numeric \tab Pf number. \cr
-   pf_player_first_name \tab character \tab Personal fouls player first name. \cr
-   pf_player_last_name \tab character \tab Personal fouls player last name. \cr
-   pf_hgt \tab character \tab Pf hgt. \cr
-   pf_wgt \tab numeric \tab Pf wgt. \cr
-   pf_yr \tab character \tab Pf yr. \cr
-   pf_min_pct \tab numeric \tab Personal fouls min percentage (0-1 decimal). \cr
-   c_number \tab numeric \tab C number. \cr
-   c_player_first_name \tab character \tab C player first name. \cr
-   c_player_last_name \tab character \tab C player last name. \cr
-   c_hgt \tab character \tab C hgt. \cr
-   c_wgt \tab numeric \tab C wgt. \cr
-   c_yr \tab character \tab C yr. \cr
-   c_min_pct \tab numeric \tab C min percentage (0-1 decimal). \cr
    team \tab character \tab Team-side label or team identifier. \cr
    year \tab numeric \tab 4-digit year. \cr
+   player_id \tab integer \tab KenPom player identifier. \cr
+   player_name \tab character \tab Player full name. \cr
+   class_year \tab character \tab Class year (e.g. 'Fr', 'So', 'Jr', 'Sr'). \cr
+   height \tab character \tab Height (e.g. '6-9'). \cr
+   weight \tab numeric \tab Weight in pounds. \cr
+   pct_pg \tab numeric \tab Percentage of the player's minutes played at point guard (0-1 decimal). \cr
+   pct_sg \tab numeric \tab Percentage of the player's minutes played at shooting guard (0-1 decimal). \cr
+   pct_sf \tab numeric \tab Percentage of the player's minutes played at small forward (0-1 decimal). \cr
+   pct_pf \tab numeric \tab Percentage of the player's minutes played at power forward (0-1 decimal). \cr
+   pct_c \tab numeric \tab Percentage of the player's minutes played at center (0-1 decimal). \cr
+   pct_poss \tab numeric \tab Percentage of team possessions used while the player was on the floor (0-1 decimal). \cr
+   fta \tab integer \tab Season free throw attempts. \cr
+   fg2a \tab integer \tab Season 2-point field goal attempts. \cr
+   fg3a \tab integer \tab Season 3-point field goal attempts. \cr
 }
 }
 \description{

--- a/tests/testthat/test-espn_mbb_betting.R
+++ b/tests/testthat/test-espn_mbb_betting.R
@@ -8,12 +8,15 @@ test_that("ESPN - Get MBB Betting", {
     skip("No rows returned from endpoint at test time")
   }
 
+  # Base columns documented on ?espn_mbb_betting -- guaranteed present
+  # whether ESPN's summary `pickcenter` is live (which ships several
+  # additional columns, e.g. over_odds / *_alternate_display_value) or
+  # empty and the Core v2 odds cascade (#136, #153, #173) populates it
+  # instead (which ships exactly this documented shape).
   cols_x1 <- c(
     "details",
     "over_under",
     "spread",
-    "over_odds",
-    "under_odds",
     "provider_id",
     "provider_name",
     "provider_priority",
@@ -26,9 +29,6 @@ test_that("ESPN - Get MBB Betting", {
     "away_team_odds_average_score",
     "away_team_odds_money_line_odds",
     "away_team_odds_spread_return",
-    "away_team_odds_current_point_spread_alternate_display_value",
-    "away_team_odds_current_spread_alternate_display_value",
-    "away_team_odds_current_money_line_alternate_display_value",
     "away_team_odds_spread_record_wins",
     "away_team_odds_spread_record_losses",
     "away_team_odds_spread_record_pushes",
@@ -42,16 +42,10 @@ test_that("ESPN - Get MBB Betting", {
     "home_team_odds_average_score",
     "home_team_odds_money_line_odds",
     "home_team_odds_spread_return",
-    "home_team_odds_current_point_spread_alternate_display_value",
-    "home_team_odds_current_spread_alternate_display_value",
-    "home_team_odds_current_money_line_alternate_display_value",
     "home_team_odds_spread_record_wins",
     "home_team_odds_spread_record_losses",
     "home_team_odds_spread_record_pushes",
     "home_team_odds_spread_record_summary",
-    "current_over_alternate_display_value",
-    "current_under_alternate_display_value",
-    "current_total_alternate_display_value",
     "game_id"
   )
 
@@ -87,4 +81,17 @@ test_that("ESPN - Get MBB Betting", {
   check_cols(x[[2]], cols_x2)
   check_cols(x[[3]], cols_x3)
 
+})
+
+test_that("ESPN - Get MBB Betting falls back to Core v2 odds when pickcenter is empty (#136, #153, #173)", {
+  skip_on_cran()
+  skip_espn_test()
+
+  x <- espn_mbb_betting(game_id = 401574046)
+
+  expect_gt(nrow(x$pickcenter), 0)
+  expect_in(
+    c("provider_id", "provider_name", "over_under", "spread", "game_id"),
+    colnames(x$pickcenter)
+  )
 })

--- a/tests/testthat/test-espn_mbb_scoreboard.R
+++ b/tests/testthat/test-espn_mbb_scoreboard.R
@@ -46,3 +46,22 @@ test_that("ESPN - Get MBB scoreboard", {
   expect_s3_class(x, "data.frame")
 
 })
+
+test_that("ESPN - MBB scoreboard for a season year includes Nov/Dec of the prior calendar year (#150)", {
+  skip_on_cran()
+  skip_espn_test()
+
+  x <- espn_mbb_scoreboard(season = 2024)
+
+  expect_gt(nrow(x), 0)
+  expect_true(all(as.integer(x$season) == 2024))
+  expect_true(any(x$game_date >= as.Date("2023-11-01") & x$game_date < as.Date("2024-01-01")))
+  expect_false(any(duplicated(x$game_id)))
+})
+
+test_that("ESPN - MBB scoreboard doesn't error for a 2002-era single-date input (#150)", {
+  skip_on_cran()
+  skip_espn_test()
+
+  expect_no_error(espn_mbb_scoreboard(season = "20011108"))
+})

--- a/tests/testthat/test-espn_mbb_standings.R
+++ b/tests/testthat/test-espn_mbb_standings.R
@@ -90,3 +90,12 @@ test_that("ESPN - Get MBB Standings", {
   expect_s3_class(x, "data.frame")
 
 })
+
+test_that("ESPN - MBB Standings includes newer D1 teams (#144)", {
+  skip_on_cran()
+  skip_espn_test()
+  x <- espn_mbb_standings(year = 2025)
+  expect_gte(nrow(x), 362)
+  expect_true(any(grepl("Southern Indiana", x$team)))
+  expect_in("conference", colnames(x))
+})

--- a/tests/testthat/test-espn_mbb_teams.R
+++ b/tests/testthat/test-espn_mbb_teams.R
@@ -29,3 +29,11 @@ test_that("ESPN - Get MBB teams", {
   expect_s3_class(x, "data.frame")
 
 })
+
+test_that("ESPN - MBB teams includes teams missing from the flat fetch (#144)", {
+  skip_on_cran()
+  skip_espn_test()
+  x <- espn_mbb_teams(year = 2025)
+  expect_gte(nrow(x), 362)
+  expect_in(c(2511, 2330, 2815, 88), x$team_id)
+})

--- a/tests/testthat/test-espn_nba_betting.R
+++ b/tests/testthat/test-espn_nba_betting.R
@@ -48,3 +48,16 @@ test_that("ESPN - Get NBA Betting", {
   expect_type(x, "list")
 
 })
+
+test_that("ESPN - Get NBA Betting falls back to Core v2 odds when pickcenter is empty (#136, #153, #173)", {
+  skip_on_cran()
+  skip_espn_test()
+
+  x <- espn_nba_betting(game_id = 401809781)
+
+  expect_gt(nrow(x$pickcenter), 0)
+  expect_in(
+    c("provider_id", "provider_name", "over_under", "spread", "game_id"),
+    colnames(x$pickcenter)
+  )
+})

--- a/tests/testthat/test-kp_team_depth_chart.R
+++ b/tests/testthat/test-kp_team_depth_chart.R
@@ -5,45 +5,25 @@ test_that("KP - Get team depth chart", {
 
   x <- kp_team_depth_chart(team = "Florida St.", year = 2020)
   cols <- c(
-    "pg_number",
-    "pg_player_first_name",
-    "pg_player_last_name",
-    "pg_hgt",
-    "pg_wgt",
-    "pg_yr",
-    "pg_min_pct",
-    "sg_number",
-    "sg_player_first_name",
-    "sg_player_last_name",
-    "sg_hgt",
-    "sg_wgt",
-    "sg_yr",
-    "sg_min_pct",
-    "sf_number",
-    "sf_player_first_name",
-    "sf_player_last_name",
-    "sf_hgt",
-    "sf_wgt",
-    "sf_yr",
-    "sf_min_pct",
-    "pf_number",
-    "pf_player_first_name",
-    "pf_player_last_name",
-    "pf_hgt",
-    "pf_wgt",
-    "pf_yr",
-    "pf_min_pct",
-    "c_number",
-    "c_player_first_name",
-    "c_player_last_name",
-    "c_hgt",
-    "c_wgt",
-    "c_yr",
-    "c_min_pct",
     "team",
-    "year"
+    "year",
+    "player_id",
+    "player_name",
+    "class_year",
+    "height",
+    "weight",
+    "pct_pg",
+    "pct_sg",
+    "pct_sf",
+    "pct_pf",
+    "pct_c",
+    "pct_poss",
+    "fta",
+    "fg2a",
+    "fg3a"
   )
 
+  expect_gt(nrow(x), 0)
   expect_in(cols, colnames(x))
   expect_s3_class(x, "data.frame")
 


### PR DESCRIPTION
## Summary

Four triage-confirmed fixes for the ESPN MBB/NBA and KenPom scrapers.

- **Betting cascade** (`espn_mbb_betting`/`espn_nba_betting`): ESPN's Site v2 `summary` payload now frequently ships an empty `pickcenter` array. Falls back to the Core v2 event odds endpoint (`.espn_basketball_event_odds`, already used by `espn_mbb_game_odds`/`espn_nba_game_odds`) and maps its columns onto the documented `pickcenter` shape when empty. Removes the now-false "ESPN does not carry NCAA basketball odds lines" comment.
- **Conference-grouped MBB teams/standings** (`espn_mbb_standings`, `espn_mbb_teams`): standings switches from ESPN's flat `level=1` list to `level=3` (conference-grouped), which includes D1 newcomers the flat list drops; adds a `conference` column. `espn_mbb_teams`'s flat `teams?limit=1000` fetch independently drops a few of the same teams even though the function's own conference-group crawl already resolves their conference membership — backfills those team_ids individually before joining conference info back on.
- **MBB scoreboard season semantics** (`espn_mbb_scoreboard`, `espn_nba_scoreboard`): `max_year <- substr(Sys.Date(), 1, 4)` was a character, so `max_year + 1` threw for out-of-range seasons — cast to integer in both. `espn_mbb_scoreboard` also passed a bare season year straight through to ESPN's `dates=` param, which ESPN treats as calendar-year-only (Jan 1 onward), silently dropping the season's November/December games. For a season-year input, additionally queries the prior calendar year, and because the high-volume regular-season group hits ESPN's `limit=1000` cap in mid-January (never reaching Nov/Dec via a single request), backfills that window with one request per day. Filtered to the season ESPN itself assigns each game and deduplicated. The documented single-date usage is unaffected.
- **KenPom depth chart** (`kp_team_depth_chart`): KenPom removed the `#dc-table` table from `team.php` — the page now ships an empty `<div id="depth-chart">` rendered client-side from a `const players = [...]` JSON array embedded in an inline `<script>` tag. Repoints the parser at that embedded JSON. The new source reports each rostered player's percentage of minutes at every position rather than a single starter/backup per slot, so the return shape changed from one wide row per team to one row per player with `pct_pg`/`pct_sg`/`pct_sf`/`pct_pf`/`pct_c` columns.

Fixes #136, #153, #173, #144, #150, #152

## Test plan

- [x] `devtools::document()` — regenerated `man/espn_mbb_standings.Rd` and `man/kp_team_depth_chart.Rd`; `NAMESPACE` unchanged
- [x] Live-verified `espn_mbb_betting(401574046)` → 13 providers via cascade; `espn_nba_betting(401809781)` → 2 providers via cascade
- [x] Live-verified `espn_mbb_standings(2025)` → 364 rows incl. Southern Indiana, Queens, Lindenwood with `conference`; `espn_mbb_teams(2025)` → 366 rows incl. all 4 issue team_ids (2511, 2330, 2815, 88)
- [x] Live-verified `espn_mbb_scoreboard(2024)` → 3726 rows, Nov 6 2023 – Apr 8 2024, 1418 Nov + 1219 Dec games, no duplicates, all `season == 2024`; single-date usage (`"20231108"`) and the pre-2002-crash regression (`"20011108"`) unaffected
- [x] Live-verified `kp_team_depth_chart("Duke", 2025)` → 14 rows; `kp_team_depth_chart("Florida St.", 2020)` → 17 rows (new template applies to historical seasons too)
- [x] Ran touched test files (`test-espn_mbb_betting.R`, `test-espn_nba_betting.R`, `test-espn_mbb_standings.R`, `test-espn_mbb_teams.R`, `test-espn_mbb_scoreboard.R`, `test-espn_nba_scoreboard.R`, `test-kp_team_depth_chart.R`) with `ESPN_TESTS=1` / KenPom creds — all pass

## Summary by Sourcery

Fix ESPN and KenPom basketball scrapers to preserve betting, team, standings, seasonal scoreboard, and depth chart data after upstream API and page changes.

Bug Fixes:
- Restore ESPN MBB and NBA betting results when summary payloads omit pickcenter odds.
- Include missing NCAA MBB teams and conference information in teams and standings data.
- Correct MBB season scoreboard retrieval to include prior-year games and avoid invalid season handling.
- Update KenPom depth chart extraction for the new player-level data source.

Enhancements:
- Change KenPom depth chart output to one row per player with positional minute shares and additional usage and shooting-volume metrics.

Documentation:
- Update standings and depth chart documentation to reflect the new output columns and depth chart structure.

Tests:
- Add live integration coverage for betting fallbacks, missing MBB teams, complete season scoreboards, standings coverage, and the revised KenPom depth chart.