### PR TITLE
ci(rhub): track r-hub/actions@v1 for node24 runtime compliance

### DIFF
--- a/.github/workflows/rhub.yaml
+++ b/.github/workflows/rhub.yaml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
     # NO NEED TO CHECKOUT HERE
-    - uses: r-hub/actions/setup@v1.7.7
+    - uses: r-hub/actions/setup@v1
       with:
         config: ${{ github.event.inputs.config }}
       id: rhub-setup
@@ -62,16 +62,16 @@ jobs:
       NCAA_MBB_TESTS: ${{ secrets.NCAA_MBB_TESTS }}
 
     steps:
-      - uses: r-hub/actions/checkout@v1.7.7
-      - uses: r-hub/actions/platform-info@v1.7.7
+      - uses: r-hub/actions/checkout@v1
+      - uses: r-hub/actions/platform-info@v1
         with:
           token: ${{ secrets.RHUB_TOKEN }}
           job-config: ${{ matrix.config.job-config }}
-      - uses: r-hub/actions/setup-deps@v1.7.7
+      - uses: r-hub/actions/setup-deps@v1
         with:
           token: ${{ secrets.RHUB_TOKEN }}
           job-config: ${{ matrix.config.job-config }}
-      - uses: r-hub/actions/run-check@v1.7.7
+      - uses: r-hub/actions/run-check@v1
         with:
           token: ${{ secrets.RHUB_TOKEN }}
           job-config: ${{ matrix.config.job-config }}
@@ -97,20 +97,20 @@ jobs:
       NCAA_MBB_TESTS: ${{ secrets.NCAA_MBB_TESTS }}
 
     steps:
-      - uses: r-hub/actions/checkout@v1.7.7
-      - uses: r-hub/actions/setup-r@v1.7.7
+      - uses: r-hub/actions/checkout@v1
+      - uses: r-hub/actions/setup-r@v1
         with:
           job-config: ${{ matrix.config.job-config }}
           token: ${{ secrets.RHUB_TOKEN }}
-      - uses: r-hub/actions/platform-info@v1.7.7
+      - uses: r-hub/actions/platform-info@v1
         with:
           token: ${{ secrets.RHUB_TOKEN }}
           job-config: ${{ matrix.config.job-config }}
-      - uses: r-hub/actions/setup-deps@v1.7.7
+      - uses: r-hub/actions/setup-deps@v1
         with:
           job-config: ${{ matrix.config.job-config }}
           token: ${{ secrets.RHUB_TOKEN }}
-      - uses: r-hub/actions/run-check@v1.7.7
+      - uses: r-hub/actions/run-check@v1
         with:
           job-config: ${{ matrix.config.job-config }}
           token: ${{ secrets.RHUB_TOKEN }}


### PR DESCRIPTION
Moves the six `r-hub/actions/*@v1.7.7` pins to the rolling `@v1` tag — v1.7.7 is node24-compliant today but pinned, so it goes stale at the next runtime transition. Matches the canonical rhub template; same change already in cfbfastR, fastRhockey, baseballr, and wehoop. Dispatch-only workflow.

## Summary by Sourcery

Track the rolling v1 versions of R-hub workflow actions to maintain compatibility across future runtime transitions.

Enhancements:
- Update all r-hub workflow actions to follow the rolling v1 release tag for ongoing runtime compatibility.

CI:
- Keep the dispatch-only R-hub workflow aligned with the canonical action versioning pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated R-hub workflow actions to use the current major-version release tag.
  * Workflow behavior and execution order remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->