### PR TITLE
docs(articles): bring the pkgdown articles onto the family template

### DIFF
--- a/data-raw/get_exported_functions.R
+++ b/data-raw/get_exported_functions.R
@@ -1,6 +1,6 @@
 library(pkgapi)
 library(tidyverse)
-pacman::p_load_current_gh("r-lib/pkgapi")
+pak::pak("r-lib/pkgapi")
 pkg <- pkgapi::map_package()
 function_calls <- pkg$calls
 exported <- pkg$defs %>%

--- a/data-raw/intro-to-hoopR.Rmd
+++ b/data-raw/intro-to-hoopR.Rmd
@@ -53,12 +53,18 @@ browser <- login(Sys.getenv("KP_USER"), Sys.getenv("KP_PW"))
 ### **Import libraries**
 
 ```{r load_import, warning=FALSE,  message = FALSE}
-# You can install using the pacman package using the following code:
-if (!requireNamespace('pacman', quietly = TRUE)){
-  install.packages('pacman')
+# You can install using the pak package using the following code:
+if (!requireNamespace('pak', quietly = TRUE)){
+  install.packages('pak')
 }
-pacman::p_load_current_gh("saiemgilani/hoopR")
-pacman::p_load(dplyr, ggplot2,animation,ggimage,png, glue)
+pak::pak("saiemgilani/hoopR")
+pak::pak(c("dplyr", "ggplot2", "animation", "ggimage", "png", "glue"))
+library(dplyr)
+library(ggplot2)
+library(animation)
+library(ggimage)
+library(png)
+library(glue)
 
 ```
 

--- a/vignettes/.gitignore
+++ b/vignettes/.gitignore
@@ -1,3 +1,2 @@
 *.html
 *.R
-parameter-descriptions.Rmd

--- a/vignettes/cbbd-college-basketball-data.Rmd
+++ b/vignettes/cbbd-college-basketball-data.Rmd
@@ -190,3 +190,45 @@ cbbd_draft_picks(year = 2024)
   parameters and the columns it returns.
 - Inspect your remaining API usage and rate limits in the response headers from
   the [CollegeBasketballData API](https://collegebasketballdata.com).
+
+# **Our Authors**
+-   [Saiem Gilani](https://x.com/saiemgilani)
+<a href='https://x.com/saiemgilani' target='blank'><img src='https://img.shields.io/twitter/follow/saiemgilani?color=blue&amp;label=%40saiemgilani&amp;logo=x&amp;style=for-the-badge' alt='@saiemgilani'/></a>
+<a href='https://github.com/saiemgilani' target='blank'><img src='https://img.shields.io/github/followers/saiemgilani?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@saiemgilani'/></a>
+
+## **Our Contributors**
+-   [Jason Lee](https://x.com/theFirmAISports)
+<a href='https://x.com/theFirmAISports' target='blank'><img src='https://img.shields.io/twitter/follow/theFirmAISports?color=blue&amp;label=%40theFirmAISports&amp;logo=x&amp;style=for-the-badge' alt='@theFirmAISports'/></a>
+-   [Billy Fryer](https://x.com/BillyFryer42)
+<a href='https://x.com/BillyFryer42' target='blank'><img src='https://img.shields.io/twitter/follow/BillyFryer42?color=blue&amp;label=%40BillyFryer42&amp;logo=x&amp;style=for-the-badge' alt='@BillyFryer42'/></a>
+-   [Ross Drucker](https://x.com/rossdrucker9)
+<a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
+-   [Vladislav Shufinskiy](https://x.com/vshufinskiy)
+<a href='https://x.com/vshufinskiy' target='blank'><img src='https://img.shields.io/twitter/follow/vshufinskiy?color=blue&amp;label=%40vshufinskiy&amp;logo=x&amp;style=for-the-badge' alt='@vshufinskiy'/></a>
+
+## **Citation**
+
+To cite the [**`hoopR`**](https://hoopR.sportsdataverse.org/) R package in publications, use:
+
+BibTex Citation
+
+```bibtex
+@misc{hoopr,
+  author = {Saiem Gilani},
+  title = {hoopR: The SportsDataverse's R Package for Men's Basketball Data},
+  url = {https://hoopR.sportsdataverse.org/},
+  year = {2026}
+}
+```
+
+## **Related SportsDataverse packages**
+
+-   [**cfbfastR**](https://cfbfastR.sportsdataverse.org/) - college football
+-   [**hoopR**](https://hoopR.sportsdataverse.org/) - men's basketball
+-   [**wehoop**](https://wehoop.sportsdataverse.org/) - women's basketball
+-   [**baseballr**](https://baseballr.sportsdataverse.org/) - baseball
+-   [**fastRhockey**](https://fastRhockey.sportsdataverse.org/) - hockey
+-   [**oddsapiR**](https://oddsapiR.sportsdataverse.org/) - betting odds
+-   [**sportyR**](https://sportyR.sportsdataverse.org/) - playing surfaces
+-   [**sportsdataverse-py**](https://py.sportsdataverse.org/) - the Python package
+-   [**sportsdataverse-R**](https://r.sportsdataverse.org/) - the R meta-package

--- a/vignettes/cbbd-college-basketball-data.Rmd
+++ b/vignettes/cbbd-college-basketball-data.Rmd
@@ -199,23 +199,27 @@ cbbd_draft_picks(year = 2024)
 ## **Our Contributors**
 -   [Jason Lee](https://x.com/theFirmAISports)
 <a href='https://x.com/theFirmAISports' target='blank'><img src='https://img.shields.io/twitter/follow/theFirmAISports?color=blue&amp;label=%40theFirmAISports&amp;logo=x&amp;style=for-the-badge' alt='@theFirmAISports'/></a>
+<a href='https://github.com/papagorgio23' target='blank'><img src='https://img.shields.io/github/followers/papagorgio23?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@papagorgio23'/></a>
 -   [Billy Fryer](https://x.com/BillyFryer42)
 <a href='https://x.com/BillyFryer42' target='blank'><img src='https://img.shields.io/twitter/follow/BillyFryer42?color=blue&amp;label=%40BillyFryer42&amp;logo=x&amp;style=for-the-badge' alt='@BillyFryer42'/></a>
+<a href='https://github.com/billyfryer' target='blank'><img src='https://img.shields.io/github/followers/billyfryer?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@billyfryer'/></a>
 -   [Ross Drucker](https://x.com/rossdrucker9)
 <a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
+<a href='https://github.com/rossdrucker' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker'/></a>
 -   [Vladislav Shufinskiy](https://x.com/vshufinskiy)
 <a href='https://x.com/vshufinskiy' target='blank'><img src='https://img.shields.io/twitter/follow/vshufinskiy?color=blue&amp;label=%40vshufinskiy&amp;logo=x&amp;style=for-the-badge' alt='@vshufinskiy'/></a>
+<a href='https://github.com/shufinskiy' target='blank'><img src='https://img.shields.io/github/followers/shufinskiy?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@shufinskiy'/></a>
 
 ## **Citation**
 
 To cite the [**`hoopR`**](https://hoopR.sportsdataverse.org/) R package in publications, use:
 
-BibTex Citation
+BibTeX Citation
 
 ```bibtex
 @misc{hoopr,
   author = {Saiem Gilani},
-  title = {hoopR: The SportsDataverse's R Package for Men's Basketball Data},
+  title = {hoopR: Access Men’s Basketball Play by Play Data.},
   url = {https://hoopR.sportsdataverse.org/},
   year = {2026}
 }

--- a/vignettes/espn-endpoints.Rmd
+++ b/vignettes/espn-endpoints.Rmd
@@ -715,3 +715,45 @@ When something looks off, an empty tibble is far more often the
 correct, expected return than a bug. ESPN's basketball coverage is
 uneven across leagues, seasons, and franchise tenures, and `hoopR`
 mirrors that unevenness honestly rather than papering over it.
+
+# **Our Authors**
+-   [Saiem Gilani](https://x.com/saiemgilani)
+<a href='https://x.com/saiemgilani' target='blank'><img src='https://img.shields.io/twitter/follow/saiemgilani?color=blue&amp;label=%40saiemgilani&amp;logo=x&amp;style=for-the-badge' alt='@saiemgilani'/></a>
+<a href='https://github.com/saiemgilani' target='blank'><img src='https://img.shields.io/github/followers/saiemgilani?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@saiemgilani'/></a>
+
+## **Our Contributors**
+-   [Jason Lee](https://x.com/theFirmAISports)
+<a href='https://x.com/theFirmAISports' target='blank'><img src='https://img.shields.io/twitter/follow/theFirmAISports?color=blue&amp;label=%40theFirmAISports&amp;logo=x&amp;style=for-the-badge' alt='@theFirmAISports'/></a>
+-   [Billy Fryer](https://x.com/BillyFryer42)
+<a href='https://x.com/BillyFryer42' target='blank'><img src='https://img.shields.io/twitter/follow/BillyFryer42?color=blue&amp;label=%40BillyFryer42&amp;logo=x&amp;style=for-the-badge' alt='@BillyFryer42'/></a>
+-   [Ross Drucker](https://x.com/rossdrucker9)
+<a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
+-   [Vladislav Shufinskiy](https://x.com/vshufinskiy)
+<a href='https://x.com/vshufinskiy' target='blank'><img src='https://img.shields.io/twitter/follow/vshufinskiy?color=blue&amp;label=%40vshufinskiy&amp;logo=x&amp;style=for-the-badge' alt='@vshufinskiy'/></a>
+
+## **Citation**
+
+To cite the [**`hoopR`**](https://hoopR.sportsdataverse.org/) R package in publications, use:
+
+BibTex Citation
+
+```bibtex
+@misc{hoopr,
+  author = {Saiem Gilani},
+  title = {hoopR: The SportsDataverse's R Package for Men's Basketball Data},
+  url = {https://hoopR.sportsdataverse.org/},
+  year = {2026}
+}
+```
+
+## **Related SportsDataverse packages**
+
+-   [**cfbfastR**](https://cfbfastR.sportsdataverse.org/) - college football
+-   [**hoopR**](https://hoopR.sportsdataverse.org/) - men's basketball
+-   [**wehoop**](https://wehoop.sportsdataverse.org/) - women's basketball
+-   [**baseballr**](https://baseballr.sportsdataverse.org/) - baseball
+-   [**fastRhockey**](https://fastRhockey.sportsdataverse.org/) - hockey
+-   [**oddsapiR**](https://oddsapiR.sportsdataverse.org/) - betting odds
+-   [**sportyR**](https://sportyR.sportsdataverse.org/) - playing surfaces
+-   [**sportsdataverse-py**](https://py.sportsdataverse.org/) - the Python package
+-   [**sportsdataverse-R**](https://r.sportsdataverse.org/) - the R meta-package

--- a/vignettes/espn-endpoints.Rmd
+++ b/vignettes/espn-endpoints.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "ESPN basketball endpoints -- NBA & MBB"
 description: "A tour of the 199 ESPN basketball endpoint wrappers in <code>hoopR</code>, grouped by use case: game data, team detail, athlete coverage, per-event enrichments, league-wide catalogs, NBA draft/transactions/free-agency endpoints, and the post-3.0.0 core-v2 deep expansion (athlete career, team-season stats, per-game player box, play personnel, typed-detail companions)."
-author: "Saiem Gilani <br><a href='https://x.com/saiemgilani' target='blank'><img src='https://img.shields.io/twitter/follow/saiemgilani?label=%40saiemgilani&amp;logo=x&amp;style=for-the-badge' alt='@saiemgilani'/></a> <a href='https://github.com/saiemgilani' target='blank'><img src='https://img.shields.io/github/followers/saiemgilani?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@saiemgilani'/></a>"
+author: "Saiem Gilani <br><a href='https://x.com/saiemgilani' target='blank'><img src='https://img.shields.io/twitter/follow/saiemgilani?color=blue&amp;label=%40saiemgilani&amp;logo=x&amp;style=for-the-badge' alt='@saiemgilani'/></a> <a href='https://github.com/saiemgilani' target='blank'><img src='https://img.shields.io/github/followers/saiemgilani?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@saiemgilani'/></a>"
 opengraph:
   image:
     src: "https://github.com/sportsdataverse/hoopR-data/blob/main/themes/hoopR_gh.png?raw=true"
@@ -724,23 +724,27 @@ mirrors that unevenness honestly rather than papering over it.
 ## **Our Contributors**
 -   [Jason Lee](https://x.com/theFirmAISports)
 <a href='https://x.com/theFirmAISports' target='blank'><img src='https://img.shields.io/twitter/follow/theFirmAISports?color=blue&amp;label=%40theFirmAISports&amp;logo=x&amp;style=for-the-badge' alt='@theFirmAISports'/></a>
+<a href='https://github.com/papagorgio23' target='blank'><img src='https://img.shields.io/github/followers/papagorgio23?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@papagorgio23'/></a>
 -   [Billy Fryer](https://x.com/BillyFryer42)
 <a href='https://x.com/BillyFryer42' target='blank'><img src='https://img.shields.io/twitter/follow/BillyFryer42?color=blue&amp;label=%40BillyFryer42&amp;logo=x&amp;style=for-the-badge' alt='@BillyFryer42'/></a>
+<a href='https://github.com/billyfryer' target='blank'><img src='https://img.shields.io/github/followers/billyfryer?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@billyfryer'/></a>
 -   [Ross Drucker](https://x.com/rossdrucker9)
 <a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
+<a href='https://github.com/rossdrucker' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker'/></a>
 -   [Vladislav Shufinskiy](https://x.com/vshufinskiy)
 <a href='https://x.com/vshufinskiy' target='blank'><img src='https://img.shields.io/twitter/follow/vshufinskiy?color=blue&amp;label=%40vshufinskiy&amp;logo=x&amp;style=for-the-badge' alt='@vshufinskiy'/></a>
+<a href='https://github.com/shufinskiy' target='blank'><img src='https://img.shields.io/github/followers/shufinskiy?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@shufinskiy'/></a>
 
 ## **Citation**
 
 To cite the [**`hoopR`**](https://hoopR.sportsdataverse.org/) R package in publications, use:
 
-BibTex Citation
+BibTeX Citation
 
 ```bibtex
 @misc{hoopr,
   author = {Saiem Gilani},
-  title = {hoopR: The SportsDataverse's R Package for Men's Basketball Data},
+  title = {hoopR: Access Men’s Basketball Play by Play Data.},
   url = {https://hoopR.sportsdataverse.org/},
   year = {2026}
 }

--- a/vignettes/getting-started-hoopR.Rmd
+++ b/vignettes/getting-started-hoopR.Rmd
@@ -159,28 +159,48 @@ glue::glue("{nrow(mbb_player_box)} rows of men's college basketball player boxsc
 dplyr::glimpse(mbb_player_box)
 ```
 
-
 # **Our Authors**
-
 -   [Saiem Gilani](https://x.com/saiemgilani)
-<a href="https://x.com/saiemgilani" target="blank"><img src="https://img.shields.io/twitter/follow/saiemgilani?color=blue&label=%40saiemgilani&logo=x&style=for-the-badge" alt="@saiemgilani" /></a>
-<a href="https://github.com/saiemgilani" target="blank"><img src="https://img.shields.io/github/followers/saiemgilani?color=eee&logo=Github&style=for-the-badge" alt="@saiemgilani" /></a>
+<a href='https://x.com/saiemgilani' target='blank'><img src='https://img.shields.io/twitter/follow/saiemgilani?color=blue&amp;label=%40saiemgilani&amp;logo=x&amp;style=for-the-badge' alt='@saiemgilani'/></a>
+<a href='https://github.com/saiemgilani' target='blank'><img src='https://img.shields.io/github/followers/saiemgilani?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@saiemgilani'/></a>
 
-
-## **Our Contributors (they're awesome)**
-
+## **Our Contributors**
 -   [Jason Lee](https://x.com/theFirmAISports)
-<a href="https://x.com/theFirmAISports" target="blank"><img src="https://img.shields.io/twitter/follow/theFirmAISports?color=blue&label=%40theFirmAISports&logo=x&style=for-the-badge" alt="@theFirmAISports" /></a>
-<a href="https://github.com/papagorgio23" target="blank"><img src="https://img.shields.io/github/followers/papagorgio23?color=eee&logo=Github&style=for-the-badge" alt="@papagorgio23" /></a>
-
+<a href='https://x.com/theFirmAISports' target='blank'><img src='https://img.shields.io/twitter/follow/theFirmAISports?color=blue&amp;label=%40theFirmAISports&amp;logo=x&amp;style=for-the-badge' alt='@theFirmAISports'/></a>
+<a href='https://github.com/papagorgio23' target='blank'><img src='https://img.shields.io/github/followers/papagorgio23?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@papagorgio23'/></a>
 -   [Billy Fryer](https://x.com/BillyFryer42)
-<a href="https://x.com/BillyFryer42" target="blank"><img src="https://img.shields.io/twitter/follow/BillyFryer42?color=blue&label=%40BillyFryer42&logo=x&style=for-the-badge" alt="@BillyFryer42" /></a>
-<a href="https://github.com/billyfryer" target="blank"><img src="https://img.shields.io/github/followers/billyfryer?color=eee&logo=Github&style=for-the-badge" alt="@billyfryer" /></a>
-
+<a href='https://x.com/BillyFryer42' target='blank'><img src='https://img.shields.io/twitter/follow/BillyFryer42?color=blue&amp;label=%40BillyFryer42&amp;logo=x&amp;style=for-the-badge' alt='@BillyFryer42'/></a>
+<a href='https://github.com/billyfryer' target='blank'><img src='https://img.shields.io/github/followers/billyfryer?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@billyfryer'/></a>
 -   [Ross Drucker](https://x.com/rossdrucker9)
-<a href="https://x.com/rossdrucker9" target="blank"><img src="https://img.shields.io/twitter/follow/rossdrucker9?color=blue&label=%40rossdrucker9&logo=x&style=for-the-badge" alt="@rossdrucker9" /></a>
-<a href="https://github.com/rossdrucker" target="blank"><img src="https://img.shields.io/github/followers/rossdrucker?color=eee&logo=Github&style=for-the-badge" alt="@rossdrucker" /></a>
-
+<a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
+<a href='https://github.com/rossdrucker' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker'/></a>
 -   [Vladislav Shufinskiy](https://x.com/vshufinskiy)
-<a href="https://x.com/vshufinskiy" target="blank"><img src="https://img.shields.io/twitter/follow/vshufinskiy?color=blue&label=%40vshufinskiy&logo=x&style=for-the-badge" alt="@vshufinskiy" /></a>
-<a href="https://github.com/shufinskiy" target="blank"><img src="https://img.shields.io/github/followers/shufinskiy?color=eee&logo=Github&style=for-the-badge" alt="@shufinskiy" /></a>
+<a href='https://x.com/vshufinskiy' target='blank'><img src='https://img.shields.io/twitter/follow/vshufinskiy?color=blue&amp;label=%40vshufinskiy&amp;logo=x&amp;style=for-the-badge' alt='@vshufinskiy'/></a>
+<a href='https://github.com/shufinskiy' target='blank'><img src='https://img.shields.io/github/followers/shufinskiy?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@shufinskiy'/></a>
+
+## **Citation**
+
+To cite the [**`hoopR`**](https://hoopR.sportsdataverse.org/) R package in publications, use:
+
+BibTeX Citation
+
+```bibtex
+@misc{hoopr,
+  author = {Saiem Gilani},
+  title = {hoopR: Access Men’s Basketball Play by Play Data.},
+  url = {https://hoopR.sportsdataverse.org/},
+  year = {2026}
+}
+```
+
+## **Related SportsDataverse packages**
+
+-   [**cfbfastR**](https://cfbfastR.sportsdataverse.org/) - college football
+-   [**hoopR**](https://hoopR.sportsdataverse.org/) - men's basketball
+-   [**wehoop**](https://wehoop.sportsdataverse.org/) - women's basketball
+-   [**baseballr**](https://baseballr.sportsdataverse.org/) - baseball
+-   [**fastRhockey**](https://fastRhockey.sportsdataverse.org/) - hockey
+-   [**oddsapiR**](https://oddsapiR.sportsdataverse.org/) - betting odds
+-   [**sportyR**](https://sportyR.sportsdataverse.org/) - playing surfaces
+-   [**sportsdataverse-py**](https://py.sportsdataverse.org/) - the Python package
+-   [**sportsdataverse-R**](https://r.sportsdataverse.org/) - the R meta-package

--- a/vignettes/getting-started-hoopR.Rmd
+++ b/vignettes/getting-started-hoopR.Rmd
@@ -43,13 +43,17 @@ I'm Saiem Gilani, one of the [authors](https://hoopR.sportsdataverse.org/authors
 
 ## **Install** [**`hoopR`**](https://hoopr.sportsdataverse.org/)
 ```{r install_hoopR_gs, message=FALSE,eval=FALSE}
-# You can install using the pacman package using the following code:
-if (!requireNamespace('pacman', quietly = TRUE)){
-  install.packages('pacman')
+# You can install using the pak package using the following code:
+if (!requireNamespace('pak', quietly = TRUE)){
+  install.packages('pak')
 }
-pacman::p_load_current_gh("sportsdataverse/hoopR", dependencies = TRUE, update = TRUE)
+pak::pak("sportsdataverse/hoopR", dependencies = TRUE, update = TRUE)
 
-pacman::p_load(dplyr, zoo, ggimage, gt)
+pak::pak(c("dplyr", "zoo", "ggimage", "gt"))
+library(dplyr)
+library(zoo)
+library(ggimage)
+library(gt)
 ```
 
 ### **The Data**

--- a/vignettes/kenpom-example-functions.Rmd
+++ b/vignettes/kenpom-example-functions.Rmd
@@ -116,23 +116,27 @@ fanmatch <- kp_fanmatch(date = "2020-03-10")
 ## **Our Contributors**
 -   [Jason Lee](https://x.com/theFirmAISports)
 <a href='https://x.com/theFirmAISports' target='blank'><img src='https://img.shields.io/twitter/follow/theFirmAISports?color=blue&amp;label=%40theFirmAISports&amp;logo=x&amp;style=for-the-badge' alt='@theFirmAISports'/></a>
+<a href='https://github.com/papagorgio23' target='blank'><img src='https://img.shields.io/github/followers/papagorgio23?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@papagorgio23'/></a>
 -   [Billy Fryer](https://x.com/BillyFryer42)
 <a href='https://x.com/BillyFryer42' target='blank'><img src='https://img.shields.io/twitter/follow/BillyFryer42?color=blue&amp;label=%40BillyFryer42&amp;logo=x&amp;style=for-the-badge' alt='@BillyFryer42'/></a>
+<a href='https://github.com/billyfryer' target='blank'><img src='https://img.shields.io/github/followers/billyfryer?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@billyfryer'/></a>
 -   [Ross Drucker](https://x.com/rossdrucker9)
 <a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
+<a href='https://github.com/rossdrucker' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker'/></a>
 -   [Vladislav Shufinskiy](https://x.com/vshufinskiy)
 <a href='https://x.com/vshufinskiy' target='blank'><img src='https://img.shields.io/twitter/follow/vshufinskiy?color=blue&amp;label=%40vshufinskiy&amp;logo=x&amp;style=for-the-badge' alt='@vshufinskiy'/></a>
+<a href='https://github.com/shufinskiy' target='blank'><img src='https://img.shields.io/github/followers/shufinskiy?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@shufinskiy'/></a>
 
 ## **Citation**
 
 To cite the [**`hoopR`**](https://hoopR.sportsdataverse.org/) R package in publications, use:
 
-BibTex Citation
+BibTeX Citation
 
 ```bibtex
 @misc{hoopr,
   author = {Saiem Gilani},
-  title = {hoopR: The SportsDataverse's R Package for Men's Basketball Data},
+  title = {hoopR: Access Men’s Basketball Play by Play Data.},
   url = {https://hoopR.sportsdataverse.org/},
   year = {2026}
 }

--- a/vignettes/kenpom-example-functions.Rmd
+++ b/vignettes/kenpom-example-functions.Rmd
@@ -107,3 +107,45 @@ fanmatch <- kp_fanmatch(date = "2020-03-10")
 
 
 ```
+
+# **Our Authors**
+-   [Saiem Gilani](https://x.com/saiemgilani)
+<a href='https://x.com/saiemgilani' target='blank'><img src='https://img.shields.io/twitter/follow/saiemgilani?color=blue&amp;label=%40saiemgilani&amp;logo=x&amp;style=for-the-badge' alt='@saiemgilani'/></a>
+<a href='https://github.com/saiemgilani' target='blank'><img src='https://img.shields.io/github/followers/saiemgilani?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@saiemgilani'/></a>
+
+## **Our Contributors**
+-   [Jason Lee](https://x.com/theFirmAISports)
+<a href='https://x.com/theFirmAISports' target='blank'><img src='https://img.shields.io/twitter/follow/theFirmAISports?color=blue&amp;label=%40theFirmAISports&amp;logo=x&amp;style=for-the-badge' alt='@theFirmAISports'/></a>
+-   [Billy Fryer](https://x.com/BillyFryer42)
+<a href='https://x.com/BillyFryer42' target='blank'><img src='https://img.shields.io/twitter/follow/BillyFryer42?color=blue&amp;label=%40BillyFryer42&amp;logo=x&amp;style=for-the-badge' alt='@BillyFryer42'/></a>
+-   [Ross Drucker](https://x.com/rossdrucker9)
+<a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
+-   [Vladislav Shufinskiy](https://x.com/vshufinskiy)
+<a href='https://x.com/vshufinskiy' target='blank'><img src='https://img.shields.io/twitter/follow/vshufinskiy?color=blue&amp;label=%40vshufinskiy&amp;logo=x&amp;style=for-the-badge' alt='@vshufinskiy'/></a>
+
+## **Citation**
+
+To cite the [**`hoopR`**](https://hoopR.sportsdataverse.org/) R package in publications, use:
+
+BibTex Citation
+
+```bibtex
+@misc{hoopr,
+  author = {Saiem Gilani},
+  title = {hoopR: The SportsDataverse's R Package for Men's Basketball Data},
+  url = {https://hoopR.sportsdataverse.org/},
+  year = {2026}
+}
+```
+
+## **Related SportsDataverse packages**
+
+-   [**cfbfastR**](https://cfbfastR.sportsdataverse.org/) - college football
+-   [**hoopR**](https://hoopR.sportsdataverse.org/) - men's basketball
+-   [**wehoop**](https://wehoop.sportsdataverse.org/) - women's basketball
+-   [**baseballr**](https://baseballr.sportsdataverse.org/) - baseball
+-   [**fastRhockey**](https://fastRhockey.sportsdataverse.org/) - hockey
+-   [**oddsapiR**](https://oddsapiR.sportsdataverse.org/) - betting odds
+-   [**sportyR**](https://sportyR.sportsdataverse.org/) - playing surfaces
+-   [**sportsdataverse-py**](https://py.sportsdataverse.org/) - the Python package
+-   [**sportsdataverse-R**](https://r.sportsdataverse.org/) - the R meta-package

--- a/vignettes/mbb-cookbook.Rmd
+++ b/vignettes/mbb-cookbook.Rmd
@@ -318,3 +318,45 @@ The women's game runs on `wehoop`, a sibling package with the exact
 same grammar. `espn_mbb_team_roster` has a mirror image in
 `espn_wbb_team_roster`; everything you just learned crosses straight
 over. That's the WBB cookbook.
+
+# **Our Authors**
+-   [Saiem Gilani](https://x.com/saiemgilani)
+<a href='https://x.com/saiemgilani' target='blank'><img src='https://img.shields.io/twitter/follow/saiemgilani?color=blue&amp;label=%40saiemgilani&amp;logo=x&amp;style=for-the-badge' alt='@saiemgilani'/></a>
+<a href='https://github.com/saiemgilani' target='blank'><img src='https://img.shields.io/github/followers/saiemgilani?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@saiemgilani'/></a>
+
+## **Our Contributors**
+-   [Jason Lee](https://x.com/theFirmAISports)
+<a href='https://x.com/theFirmAISports' target='blank'><img src='https://img.shields.io/twitter/follow/theFirmAISports?color=blue&amp;label=%40theFirmAISports&amp;logo=x&amp;style=for-the-badge' alt='@theFirmAISports'/></a>
+-   [Billy Fryer](https://x.com/BillyFryer42)
+<a href='https://x.com/BillyFryer42' target='blank'><img src='https://img.shields.io/twitter/follow/BillyFryer42?color=blue&amp;label=%40BillyFryer42&amp;logo=x&amp;style=for-the-badge' alt='@BillyFryer42'/></a>
+-   [Ross Drucker](https://x.com/rossdrucker9)
+<a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
+-   [Vladislav Shufinskiy](https://x.com/vshufinskiy)
+<a href='https://x.com/vshufinskiy' target='blank'><img src='https://img.shields.io/twitter/follow/vshufinskiy?color=blue&amp;label=%40vshufinskiy&amp;logo=x&amp;style=for-the-badge' alt='@vshufinskiy'/></a>
+
+## **Citation**
+
+To cite the [**`hoopR`**](https://hoopR.sportsdataverse.org/) R package in publications, use:
+
+BibTex Citation
+
+```bibtex
+@misc{hoopr,
+  author = {Saiem Gilani},
+  title = {hoopR: The SportsDataverse's R Package for Men's Basketball Data},
+  url = {https://hoopR.sportsdataverse.org/},
+  year = {2026}
+}
+```
+
+## **Related SportsDataverse packages**
+
+-   [**cfbfastR**](https://cfbfastR.sportsdataverse.org/) - college football
+-   [**hoopR**](https://hoopR.sportsdataverse.org/) - men's basketball
+-   [**wehoop**](https://wehoop.sportsdataverse.org/) - women's basketball
+-   [**baseballr**](https://baseballr.sportsdataverse.org/) - baseball
+-   [**fastRhockey**](https://fastRhockey.sportsdataverse.org/) - hockey
+-   [**oddsapiR**](https://oddsapiR.sportsdataverse.org/) - betting odds
+-   [**sportyR**](https://sportyR.sportsdataverse.org/) - playing surfaces
+-   [**sportsdataverse-py**](https://py.sportsdataverse.org/) - the Python package
+-   [**sportsdataverse-R**](https://r.sportsdataverse.org/) - the R meta-package

--- a/vignettes/mbb-cookbook.Rmd
+++ b/vignettes/mbb-cookbook.Rmd
@@ -327,23 +327,27 @@ over. That's the WBB cookbook.
 ## **Our Contributors**
 -   [Jason Lee](https://x.com/theFirmAISports)
 <a href='https://x.com/theFirmAISports' target='blank'><img src='https://img.shields.io/twitter/follow/theFirmAISports?color=blue&amp;label=%40theFirmAISports&amp;logo=x&amp;style=for-the-badge' alt='@theFirmAISports'/></a>
+<a href='https://github.com/papagorgio23' target='blank'><img src='https://img.shields.io/github/followers/papagorgio23?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@papagorgio23'/></a>
 -   [Billy Fryer](https://x.com/BillyFryer42)
 <a href='https://x.com/BillyFryer42' target='blank'><img src='https://img.shields.io/twitter/follow/BillyFryer42?color=blue&amp;label=%40BillyFryer42&amp;logo=x&amp;style=for-the-badge' alt='@BillyFryer42'/></a>
+<a href='https://github.com/billyfryer' target='blank'><img src='https://img.shields.io/github/followers/billyfryer?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@billyfryer'/></a>
 -   [Ross Drucker](https://x.com/rossdrucker9)
 <a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
+<a href='https://github.com/rossdrucker' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker'/></a>
 -   [Vladislav Shufinskiy](https://x.com/vshufinskiy)
 <a href='https://x.com/vshufinskiy' target='blank'><img src='https://img.shields.io/twitter/follow/vshufinskiy?color=blue&amp;label=%40vshufinskiy&amp;logo=x&amp;style=for-the-badge' alt='@vshufinskiy'/></a>
+<a href='https://github.com/shufinskiy' target='blank'><img src='https://img.shields.io/github/followers/shufinskiy?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@shufinskiy'/></a>
 
 ## **Citation**
 
 To cite the [**`hoopR`**](https://hoopR.sportsdataverse.org/) R package in publications, use:
 
-BibTex Citation
+BibTeX Citation
 
 ```bibtex
 @misc{hoopr,
   author = {Saiem Gilani},
-  title = {hoopR: The SportsDataverse's R Package for Men's Basketball Data},
+  title = {hoopR: Access Men’s Basketball Play by Play Data.},
   url = {https://hoopR.sportsdataverse.org/},
   year = {2026}
 }

--- a/vignettes/nba-cookbook.Rmd
+++ b/vignettes/nba-cookbook.Rmd
@@ -394,3 +394,45 @@ but it is *regular* -- and regular things are guessable.
 When you want the men's college game, the same grammar carries over
 almost unchanged -- swap `nba` for `mbb`, meet a new prefix (`kp_` for
 KenPom), and keep cooking. That's the MBB cookbook.
+
+# **Our Authors**
+-   [Saiem Gilani](https://x.com/saiemgilani)
+<a href='https://x.com/saiemgilani' target='blank'><img src='https://img.shields.io/twitter/follow/saiemgilani?color=blue&amp;label=%40saiemgilani&amp;logo=x&amp;style=for-the-badge' alt='@saiemgilani'/></a>
+<a href='https://github.com/saiemgilani' target='blank'><img src='https://img.shields.io/github/followers/saiemgilani?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@saiemgilani'/></a>
+
+## **Our Contributors**
+-   [Jason Lee](https://x.com/theFirmAISports)
+<a href='https://x.com/theFirmAISports' target='blank'><img src='https://img.shields.io/twitter/follow/theFirmAISports?color=blue&amp;label=%40theFirmAISports&amp;logo=x&amp;style=for-the-badge' alt='@theFirmAISports'/></a>
+-   [Billy Fryer](https://x.com/BillyFryer42)
+<a href='https://x.com/BillyFryer42' target='blank'><img src='https://img.shields.io/twitter/follow/BillyFryer42?color=blue&amp;label=%40BillyFryer42&amp;logo=x&amp;style=for-the-badge' alt='@BillyFryer42'/></a>
+-   [Ross Drucker](https://x.com/rossdrucker9)
+<a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
+-   [Vladislav Shufinskiy](https://x.com/vshufinskiy)
+<a href='https://x.com/vshufinskiy' target='blank'><img src='https://img.shields.io/twitter/follow/vshufinskiy?color=blue&amp;label=%40vshufinskiy&amp;logo=x&amp;style=for-the-badge' alt='@vshufinskiy'/></a>
+
+## **Citation**
+
+To cite the [**`hoopR`**](https://hoopR.sportsdataverse.org/) R package in publications, use:
+
+BibTex Citation
+
+```bibtex
+@misc{hoopr,
+  author = {Saiem Gilani},
+  title = {hoopR: The SportsDataverse's R Package for Men's Basketball Data},
+  url = {https://hoopR.sportsdataverse.org/},
+  year = {2026}
+}
+```
+
+## **Related SportsDataverse packages**
+
+-   [**cfbfastR**](https://cfbfastR.sportsdataverse.org/) - college football
+-   [**hoopR**](https://hoopR.sportsdataverse.org/) - men's basketball
+-   [**wehoop**](https://wehoop.sportsdataverse.org/) - women's basketball
+-   [**baseballr**](https://baseballr.sportsdataverse.org/) - baseball
+-   [**fastRhockey**](https://fastRhockey.sportsdataverse.org/) - hockey
+-   [**oddsapiR**](https://oddsapiR.sportsdataverse.org/) - betting odds
+-   [**sportyR**](https://sportyR.sportsdataverse.org/) - playing surfaces
+-   [**sportsdataverse-py**](https://py.sportsdataverse.org/) - the Python package
+-   [**sportsdataverse-R**](https://r.sportsdataverse.org/) - the R meta-package

--- a/vignettes/nba-cookbook.Rmd
+++ b/vignettes/nba-cookbook.Rmd
@@ -403,23 +403,27 @@ KenPom), and keep cooking. That's the MBB cookbook.
 ## **Our Contributors**
 -   [Jason Lee](https://x.com/theFirmAISports)
 <a href='https://x.com/theFirmAISports' target='blank'><img src='https://img.shields.io/twitter/follow/theFirmAISports?color=blue&amp;label=%40theFirmAISports&amp;logo=x&amp;style=for-the-badge' alt='@theFirmAISports'/></a>
+<a href='https://github.com/papagorgio23' target='blank'><img src='https://img.shields.io/github/followers/papagorgio23?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@papagorgio23'/></a>
 -   [Billy Fryer](https://x.com/BillyFryer42)
 <a href='https://x.com/BillyFryer42' target='blank'><img src='https://img.shields.io/twitter/follow/BillyFryer42?color=blue&amp;label=%40BillyFryer42&amp;logo=x&amp;style=for-the-badge' alt='@BillyFryer42'/></a>
+<a href='https://github.com/billyfryer' target='blank'><img src='https://img.shields.io/github/followers/billyfryer?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@billyfryer'/></a>
 -   [Ross Drucker](https://x.com/rossdrucker9)
 <a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
+<a href='https://github.com/rossdrucker' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker'/></a>
 -   [Vladislav Shufinskiy](https://x.com/vshufinskiy)
 <a href='https://x.com/vshufinskiy' target='blank'><img src='https://img.shields.io/twitter/follow/vshufinskiy?color=blue&amp;label=%40vshufinskiy&amp;logo=x&amp;style=for-the-badge' alt='@vshufinskiy'/></a>
+<a href='https://github.com/shufinskiy' target='blank'><img src='https://img.shields.io/github/followers/shufinskiy?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@shufinskiy'/></a>
 
 ## **Citation**
 
 To cite the [**`hoopR`**](https://hoopR.sportsdataverse.org/) R package in publications, use:
 
-BibTex Citation
+BibTeX Citation
 
 ```bibtex
 @misc{hoopr,
   author = {Saiem Gilani},
-  title = {hoopR: The SportsDataverse's R Package for Men's Basketball Data},
+  title = {hoopR: Access Men’s Basketball Play by Play Data.},
   url = {https://hoopR.sportsdataverse.org/},
   year = {2026}
 }

--- a/vignettes/parameter-descriptions.Rmd
+++ b/vignettes/parameter-descriptions.Rmd
@@ -1,0 +1,70 @@
+---
+title: "NBA Stats API Parameter Descriptions"
+author: "Saiem Gilani <br><a href='https://x.com/saiemgilani' target='blank'><img src='https://img.shields.io/twitter/follow/saiemgilani?color=blue&amp;label=%40saiemgilani&amp;logo=x&amp;style=for-the-badge' alt='@saiemgilani'/></a> <a href='https://github.com/saiemgilani' target='blank'><img src='https://img.shields.io/github/followers/saiemgilani?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@saiemgilani'/></a>"
+opengraph:
+  image:
+    src: "https://raw.githubusercontent.com/sportsdataverse/hoopR-mbb-data/main/themes/hoopR_gh.png"
+  twitter:
+    card: summary_large_image
+    creator: "@saiemgilani"
+output: html_document
+description: "A searchable reference table of every query parameter used by the NBA Stats API endpoints in <code>hoopR</code>, with accepted values and defaults."
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  echo = FALSE,
+  comment = "#>"
+)
+with_dt <- requireNamespace("DT")
+```
+
+```{r eval = with_dt}
+DT::datatable(hoopR::parameter_descriptions,options = list(scrollX = TRUE, pageLength = 25), filter = "top", rownames = FALSE)
+```
+
+```{r eval = !with_dt}
+knitr::kable(hoopR::parameter_descriptions)
+```
+
+# **Our Authors**
+-   [Saiem Gilani](https://x.com/saiemgilani)
+<a href='https://x.com/saiemgilani' target='blank'><img src='https://img.shields.io/twitter/follow/saiemgilani?color=blue&amp;label=%40saiemgilani&amp;logo=x&amp;style=for-the-badge' alt='@saiemgilani'/></a>
+<a href='https://github.com/saiemgilani' target='blank'><img src='https://img.shields.io/github/followers/saiemgilani?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@saiemgilani'/></a>
+
+## **Our Contributors**
+-   [Jason Lee](https://x.com/theFirmAISports)
+<a href='https://x.com/theFirmAISports' target='blank'><img src='https://img.shields.io/twitter/follow/theFirmAISports?color=blue&amp;label=%40theFirmAISports&amp;logo=x&amp;style=for-the-badge' alt='@theFirmAISports'/></a>
+-   [Billy Fryer](https://x.com/BillyFryer42)
+<a href='https://x.com/BillyFryer42' target='blank'><img src='https://img.shields.io/twitter/follow/BillyFryer42?color=blue&amp;label=%40BillyFryer42&amp;logo=x&amp;style=for-the-badge' alt='@BillyFryer42'/></a>
+-   [Ross Drucker](https://x.com/rossdrucker9)
+<a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
+-   [Vladislav Shufinskiy](https://x.com/vshufinskiy)
+<a href='https://x.com/vshufinskiy' target='blank'><img src='https://img.shields.io/twitter/follow/vshufinskiy?color=blue&amp;label=%40vshufinskiy&amp;logo=x&amp;style=for-the-badge' alt='@vshufinskiy'/></a>
+
+## **Citation**
+
+To cite the [**`hoopR`**](https://hoopR.sportsdataverse.org/) R package in publications, use:
+
+BibTex Citation
+
+```bibtex
+@misc{hoopr,
+  author = {Saiem Gilani},
+  title = {hoopR: The SportsDataverse's R Package for Men's Basketball Data},
+  url = {https://hoopR.sportsdataverse.org/},
+  year = {2026}
+}
+```
+
+## **Related SportsDataverse packages**
+
+-   [**cfbfastR**](https://cfbfastR.sportsdataverse.org/) - college football
+-   [**hoopR**](https://hoopR.sportsdataverse.org/) - men's basketball
+-   [**wehoop**](https://wehoop.sportsdataverse.org/) - women's basketball
+-   [**baseballr**](https://baseballr.sportsdataverse.org/) - baseball
+-   [**fastRhockey**](https://fastRhockey.sportsdataverse.org/) - hockey
+-   [**oddsapiR**](https://oddsapiR.sportsdataverse.org/) - betting odds
+-   [**sportyR**](https://sportyR.sportsdataverse.org/) - playing surfaces
+-   [**sportsdataverse-py**](https://py.sportsdataverse.org/) - the Python package
+-   [**sportsdataverse-R**](https://r.sportsdataverse.org/) - the R meta-package

--- a/vignettes/parameter-descriptions.Rmd
+++ b/vignettes/parameter-descriptions.Rmd
@@ -35,23 +35,27 @@ knitr::kable(hoopR::parameter_descriptions)
 ## **Our Contributors**
 -   [Jason Lee](https://x.com/theFirmAISports)
 <a href='https://x.com/theFirmAISports' target='blank'><img src='https://img.shields.io/twitter/follow/theFirmAISports?color=blue&amp;label=%40theFirmAISports&amp;logo=x&amp;style=for-the-badge' alt='@theFirmAISports'/></a>
+<a href='https://github.com/papagorgio23' target='blank'><img src='https://img.shields.io/github/followers/papagorgio23?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@papagorgio23'/></a>
 -   [Billy Fryer](https://x.com/BillyFryer42)
 <a href='https://x.com/BillyFryer42' target='blank'><img src='https://img.shields.io/twitter/follow/BillyFryer42?color=blue&amp;label=%40BillyFryer42&amp;logo=x&amp;style=for-the-badge' alt='@BillyFryer42'/></a>
+<a href='https://github.com/billyfryer' target='blank'><img src='https://img.shields.io/github/followers/billyfryer?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@billyfryer'/></a>
 -   [Ross Drucker](https://x.com/rossdrucker9)
 <a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
+<a href='https://github.com/rossdrucker' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker'/></a>
 -   [Vladislav Shufinskiy](https://x.com/vshufinskiy)
 <a href='https://x.com/vshufinskiy' target='blank'><img src='https://img.shields.io/twitter/follow/vshufinskiy?color=blue&amp;label=%40vshufinskiy&amp;logo=x&amp;style=for-the-badge' alt='@vshufinskiy'/></a>
+<a href='https://github.com/shufinskiy' target='blank'><img src='https://img.shields.io/github/followers/shufinskiy?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@shufinskiy'/></a>
 
 ## **Citation**
 
 To cite the [**`hoopR`**](https://hoopR.sportsdataverse.org/) R package in publications, use:
 
-BibTex Citation
+BibTeX Citation
 
 ```bibtex
 @misc{hoopr,
   author = {Saiem Gilani},
-  title = {hoopR: The SportsDataverse's R Package for Men's Basketball Data},
+  title = {hoopR: Access Men’s Basketball Play by Play Data.},
   url = {https://hoopR.sportsdataverse.org/},
   year = {2026}
 }


### PR DESCRIPTION
Across the 11 SportsDataverse R packages, **43 of 47 articles had no
author/contributor footer and 44 had no citation block** — including all 16
cfbfastR articles and all 7 hoopR ones. Every article is a potential landing
page from search or a shared link, and almost none of them told the reader who
wrote the package or how to cite it.

This adds **only what each article was missing**. Conformant headers and
footers are left byte-identical, so this is a backfill, not a rewrite.

| element | what it adds |
|---|---|
| author line | name + X/GitHub follow badges, generated from `DESCRIPTION` so authors and contributors stay in sync with the package rather than being hand-listed |
| description | lifted from the article's **own opening prose** |
| opengraph + twitter | `summary_large_image` pointing at the package's social card |
| footer | Our Authors → Contributors → Citation (BibTeX) → Related packages |

**Two judgement calls worth flagging:**

- **Articles with no prose get no description.** Parameter tables and pure
  code walk-throughs have nothing to lift, and a filler line
  (`"Getting Started - sportyR."`) reads worse than an absent one, because
  pkgdown prints it under the title on the article index and search engines
  lift it verbatim.
- **The twitter creator is per package, not uniformly `@saiemgilani`.**
  cfbfastR has its own `@cfbfastR`; sportyR is `@sportyR_pkg` (Ross Drucker's);
  and articles written by a specific contributor keep that contributor's
  handle.

## Summary by Sourcery

Standardize hoopR article pages around the family pkgdown template while preserving article-specific content and metadata.

Enhancements:
- Bring hoopR articles into the standard pkgdown article template with consistent author, description, social metadata, footer, citation, and related-package sections.

Build:
- Replace the data-generation dependency bootstrap with pak.

Documentation:
- Add and update hoopR articles with package-authored metadata, contributor attribution, citation information, and improved social sharing presentation.

Chores:
- Add the parameter descriptions article and adjust vignette tracking configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added author and contributor credits to basketball data, API, and cookbook guides.
  * Added a BibTeX citation for the `hoopR` package.
  * Added links to related SportsDataverse packages.
  * Added a searchable NBA Stats API parameter reference with filtering and a fallback table view.
  * Updated installation guidance to use `pak` for package setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->