### PR TITLE
fix(nba): correct the event_num typo in .players_on_court()

### DIFF
--- a/R/nba_stats_pbp.R
+++ b/R/nba_stats_pbp.R
@@ -151,8 +151,8 @@ NULL
         if (off > on) {
           all_id <- all_id[all_id != i]
         } else if (off == on) {
-          on_event <- min(pbp_data_period$even_num[pbp_data_period$event_type == 8 & pbp_data_period$player2_id == i])
-          off_event <- min(pbp_data_period$even_num[pbp_data_period$event_type == 8 & pbp_data_period$player1_id == i])
+          on_event <- min(pbp_data_period$event_num[pbp_data_period$event_type == 8 & pbp_data_period$player2_id == i])
+          off_event <- min(pbp_data_period$event_num[pbp_data_period$event_type == 8 & pbp_data_period$player1_id == i])
           if (off_event > on_event) {
             all_id <- all_id[all_id != i]
           }


### PR DESCRIPTION
Extracted from #186, with credit to @jacobpstein.

`.players_on_court()`'s `off == on` fallback branch reads
`pbp_data_period$even_num`. That column does not exist — it is `event_num`,
used correctly in the identical branch at lines 99–100 and documented in the
function's own returns table. Indexing a missing column gives `NULL`, so
`min()` over it errors.

The branch only fires when a player is subbed on and off at the *exact* same
clock time in the same period, which is why it went unnoticed.

**The other two fixes in #186 are no longer needed** — both landed on `main`
independently since April:

| reported | status on `main` |
|---|---|
| `even_num` typo | **still present** — fixed here |
| `load_nba_team_box()` accepts `dbConnection` but never writes | already fixed: it has both `in_db <- TRUE` and `DBI::dbWriteTable` |
| `games` used outside its `tryCatch` in three scoreboard fns | already fixed: all three initialise `games <- .empty_hoopR_data(...)` before the `tryCatch` |

#186 itself is not mergeable as-is: the branch has drifted far from `main` and
its diff is +143,039/−16,730 across 100+ files, almost all of it unrelated
divergence rather than the intended three-file change.

## Summary by Sourcery

Bug Fixes:
- Correct the play-by-play event column used by `.players_on_court()` when substitution on and off times are identical, preventing errors from indexing a nonexistent column.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue affecting on-court player tracking when players entered and exited through substitution events.
  - Substitution event numbers are now calculated correctly without triggering a missing-column error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->